### PR TITLE
Store Cairo::FtFontFace with Font_cairo to fix Windows font loading.

### DIFF
--- a/src/platform/cairo/graphic_cairo.cpp
+++ b/src/platform/cairo/graphic_cairo.cpp
@@ -50,12 +50,18 @@ void Font_cairo::loadFont(const string& file) {
   _family = (const char*)family;
   _file_name_map[file] = _family;
 
+  _fface = Cairo::FtFontFace::create(p);
+
   // release
   FcPatternDestroy(p);
 }
 
 string Font_cairo::getFamily() const {
   return _family;
+}
+
+Cairo::RefPtr<Cairo::FtFontFace> Font_cairo::getCairoFontFace() const {
+  return _fface;
 }
 
 int Font_cairo::getStyle() const {
@@ -275,21 +281,7 @@ void Graphics2D_cairo::drawChar(wchar_t c, float x, float y) {
 }
 
 void Graphics2D_cairo::drawText(const wstring& t, float x, float y) {
-  Cairo::FontSlant slant = Cairo::FONT_SLANT_NORMAL;
-  Cairo::FontWeight weight = Cairo::FONT_WEIGHT_NORMAL;
-  switch (_font->getStyle()) {
-    case BOLD:
-      weight = Cairo::FONT_WEIGHT_BOLD;
-      break;
-    case ITALIC:
-      slant = Cairo::FONT_SLANT_ITALIC;
-      break;
-    case BOLDITALIC:
-      slant = Cairo::FONT_SLANT_ITALIC;
-      weight = Cairo::FONT_WEIGHT_BOLD;
-      break;
-  }
-  _context->select_font_face(_font->getFamily(), slant, weight);
+  _context->set_font_face(_font->getCairoFontFace());
   _context->set_font_size(_font->getSize());
   _context->move_to(x, y);
   _context->show_text(wide2utf8(t.c_str()));

--- a/src/platform/cairo/graphic_cairo.h
+++ b/src/platform/cairo/graphic_cairo.h
@@ -22,6 +22,7 @@ private:
   int _style;
   double _size;
   string _family;
+  Cairo::RefPtr<Cairo::FtFontFace> _fface;
 
   void loadFont(const string& file);
 
@@ -33,6 +34,8 @@ public:
   string getFamily() const;
 
   int getStyle() const;
+
+  Cairo::RefPtr<Cairo::FtFontFace> getCairoFontFace() const;
 
   virtual float getSize() const override;
 


### PR DESCRIPTION
See #10. Only tested this on Windows. I am not sure how this will interact with the `// already loaded` branch of `Font_cairo::loadFont` (probably not well), but I haven't been able to find any circumstance under which this branch is taken. For completeness, it would be good to do something to make sure `_fface` gets populated correctly in that case either way.