### PR TITLE
Added type conversions

### DIFF
--- a/src/res/parser/font_parser.cpp
+++ b/src/res/parser/font_parser.cpp
@@ -45,7 +45,7 @@ void DefaultTeXFontParser::parse_extension(const XMLElement* e, wchar_t c, __Bas
 void DefaultTeXFontParser::parse_kern(const XMLElement* e, wchar_t c, __BasicInfo& f) {
   const __Kern kern{
       .left  = c,
-      .right = getIntAndCheck("code", e),
+      .right = (wchar_t)getIntAndCheck("code", e),
       .kern  = getFloatAndCheck("val", e),
   };
   f.kerns.push_back(kern);
@@ -54,8 +54,8 @@ void DefaultTeXFontParser::parse_kern(const XMLElement* e, wchar_t c, __BasicInf
 void DefaultTeXFontParser::parse_lig(const XMLElement* e, wchar_t c, __BasicInfo& f) {
   const __Lig lig{
       .left  = c,
-      .right = getIntAndCheck("code", e),
-      .lig   = getIntAndCheck("ligCode", e),
+      .right = (wchar_t)getIntAndCheck("code", e),
+      .lig   = (wchar_t)getIntAndCheck("ligCode", e),
   };
   f.ligs.push_back(lig);
 }
@@ -63,7 +63,7 @@ void DefaultTeXFontParser::parse_lig(const XMLElement* e, wchar_t c, __BasicInfo
 void DefaultTeXFontParser::parse_larger(const XMLElement* e, wchar_t c, __BasicInfo& f) {
   const __Larger larger{
       .code   = c,
-      .larger = getIntAndCheck("code", e),
+      .larger = (wchar_t)getIntAndCheck("code", e),
       .fontId = __id(getAttrValueAndCheckIfNotNull("fontId", e)),
   };
   f.largers.push_back(larger);


### PR DESCRIPTION
Some `int`s have changed to `wchar_t` in one of the recent commits of font_parser; I've added explicit type conversions for these.

(Sorry, I think I did something wrong in the previous pull request, so I closed it - it's my first time creating a pull request! Hopefully this one works.)