### PR TITLE
Initial Qt supporting version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 project(LaTeX)
 
 
@@ -23,23 +23,30 @@ file(COPY res DESTINATION .)
 
 file(GLOB_RECURSE SRC "src/*.cpp")
 
-
 # check operating system
 
-if(WIN32)
+if(QT)
+    message(STATUS, "Cross platform build using Qt")
+    add_compile_definitions(BUILD_QT)
+    include_directories("src")
+    set(CMAKE_AUTOMOC ON)
+    find_package(Qt5 COMPONENTS Widgets REQUIRED)
+    set(LINK_LIBS Qt5::Widgets)
+elseif(WIN32)
     message(STATUS "We are working on Windows")
+    add_compile_definitions(BUILD_WIN32)
     include_directories("src")
     set(LINK_LIBS gdiplus)
-# elseif(UNIX AND NOT APPLE)
 elseif(UNIX)
-    message(STATUS "We are working on Unix like os")
+    message(STATUS "We are working with GTK on a Unix like OS")
+    add_compile_definitions(BUILD_GTK)
     find_package(PkgConfig)
     find_package(Fontconfig REQUIRED)
     # include gtkmm module
     pkg_check_modules(GTKMM gtkmm-3.0)
     # include gtksourceview
     pkg_check_modules(GSVMM gtksourceviewmm-3.0)
-    # inlcudes and libraries
+    # includes and libraries
     link_directories(${GTKMM_LIBRARY_DIRS} ${GSVMM_LIBRARY_DIRS} ${Fontconfig_LIBRARY_DIRS})
     include_directories(${GTKMM_INCLUDE_DIRS} ${GSVMM_INCLUDE_DIRS} ${Fontconfig_INCLUDE_DIRS} "src")
     set(LINK_LIBS ${GTKMM_LIBRARIES} ${GSVMM_LIBRARIES} ${Fontconfig_LIBRARIES})
@@ -47,7 +54,6 @@ else()
     message(STATUS "We are working on a unknown platform")
     # other platforms...
 endif()
-
 
 # compile options
 
@@ -65,6 +71,8 @@ option(MEM_CHECK "If compile for memory check only" OFF)
 if(MEM_CHECK)
     add_definitions(-DMEM_CHECK)
 endif()
+
+option(QT "Compile using Qt instead of Win32/Gtk" OFF)
 
 add_executable(LaTeX ${SRC})
 target_link_libraries(LaTeX ${LINK_LIBS})

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![logo](readme/tex_logo.svg)
 
-It is a dynamic, cross-platform, and embeddable LaTeX rendering library. Its main purpose is to display mathematical formulas written in LaTeX. It can be embedded in applications on various platforms (Android, iOS, Windows, Linux...). The following pictures demonstrate the application run in Ubuntu and Windows.
+It is a dynamic, cross-platform, and embeddable LaTeX rendering library. Its main purpose is to display mathematical formulas written in LaTeX. It can be embedded in applications on various platforms (Android, iOS, Windows, Linux GTK, Qt...). The following pictures demonstrate the application run in Ubuntu (using GTK) and Windows.
 
 ![demo ubuntu](readme/example_ubuntu.png)
 
@@ -13,7 +13,8 @@ It is a dynamic, cross-platform, and embeddable LaTeX rendering library. Its mai
 First make sure you have a C++ compiler that supports `C++ 11` or `C++ 0x` standard. It uses CMake to build the demo, make sure you have it installed. Currently support Windows and Linux on PC, the version on Mac OS is in the plan, and you can find the Android version in [here](https://github.com/NanoMichael/AndroidLaTeXMath).
 
 - `CygWin` or `MinGW` is recommended to be installed on Windows, and `Gdiplus` is required.
-- `GTKMM` and `GSVMM` must be installed on Linux.
+- `GTKMM` and `GSVMM` must be installed on Linux for a GTK build.
+- Qt development packages must be installed for a Qt installation.
 
 After all the dependencies have been satisfied, run the following commands to build:
 
@@ -26,6 +27,8 @@ make -j32
 ```
 
 After all the works have done, run the executable file `LaTeX` in the directory `build` to check the demo.
+
+If you wish to build in Qt mode on your plaform add `-DQT=ON` to the cmake command above.
 
 ## Headless mode
 

--- a/src/platform/cairo/graphic_cairo.cpp
+++ b/src/platform/cairo/graphic_cairo.cpp
@@ -1,6 +1,6 @@
 #include "config.h"
 
-#if defined(__OS_Unix_like_PC__) && !defined(MEM_CHECK)
+#if defined(BUILD_GTK) && !defined(MEM_CHECK)
 
 #include "platform/cairo/graphic_cairo.h"
 

--- a/src/platform/cairo/graphic_cairo.h
+++ b/src/platform/cairo/graphic_cairo.h
@@ -1,6 +1,6 @@
 #include "config.h"
 
-#if defined(__OS_Unix_like_PC__) && !defined(MEM_CHECK)
+#if defined(BUILD_GTK) && !defined(MEM_CHECK)
 
 #ifndef GRAPHIC_CAIRO_H_INCLUDED
 #define GRAPHIC_CAIRO_H_INCLUDED
@@ -130,4 +130,4 @@ public:
 }  // namespace tex
 
 #endif  // GRAPHIC_CAIRO_H_INCLUDED
-#endif  // __OS_Unix_like_PC__ && !MEM_CHECK
+#endif  // BUILD_GTK && !MEM_CHECK

--- a/src/platform/gdi_win/graphic_win32.cpp
+++ b/src/platform/gdi_win/graphic_win32.cpp
@@ -1,6 +1,6 @@
 #include "config.h"
 
-#if defined(__OS_Windows__) && !defined(MEM_CHECK)
+#if defined(BUILD_WIN32) && !defined(MEM_CHECK)
 
 #include "platform/gdi_win/graphic_win32.h"
 

--- a/src/platform/qt/graphic_qt.cpp
+++ b/src/platform/qt/graphic_qt.cpp
@@ -1,0 +1,334 @@
+#include "graphic_qt.h"
+
+#include "config.h"
+
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
+
+#include "platform/qt/graphic_qt.h"
+
+#include <QDebug>
+
+#include <QBrush>
+#include <QColor>
+#include <QFont>
+#include <QFontDatabase>
+#include <QPainter>
+#include <QPen>
+#include <QPointF>
+#include <QRectF>
+#include <QString>
+#include <QStringList>
+#include <QTransform>
+#include <QtMath>
+
+using namespace tex;
+using namespace std;
+
+QMap<QString, QString> Font_qt::_loaded_families;
+
+namespace tex {
+// Some wstrings arrive with a \0 at end, so we remove when converting
+QString wstring_to_QString(const wstring& ws)
+{
+  QString out = QString::fromStdWString(ws);
+  auto index = out.indexOf('\0');
+  if (index != -1)
+    out.truncate(index);
+  return out;
+}
+}
+
+Font_qt::Font_qt(const string& family, int style, float size) {
+
+  //qInfo() << "new font" << QString::fromStdString(family) << style << size;
+
+  _font.setFamily(QString::fromStdString(family));
+  _font.setPointSizeF(size);
+
+  _font.setBold(style & BOLD);
+  _font.setItalic(style & ITALIC);
+}
+
+Font_qt::Font_qt(const string& file, float size)
+{
+  //qInfo() << "new font" << QString::fromStdString(file) << size;
+
+  // set size for newly loaded and previously loaded font
+  _font.setPointSizeF(size);
+
+  QString filename(QString::fromStdString(file));
+
+  if(_loaded_families.contains(filename)) {
+    // file already loaded
+    _font.setFamily(_loaded_families.value(filename));
+#ifdef HAVE_LOG
+    __log << file << " already loaded, skip\n";
+#endif
+    return;
+  }
+
+  QFontDatabase db;
+  int id = db.addApplicationFont(QString::fromStdString(file));
+  if( id == -1 ) {
+#ifdef HAVE_LOG
+    __log << file << " failed to load\n";
+#endif
+  } else {
+    QStringList families = db.applicationFontFamilies(id);
+    if( families.size() > 0 ) {
+      _loaded_families[filename] = families.first();
+      _font.setFamily(families.first());
+    } else {
+#ifdef HAVE_LOG
+    __log << file << " no font families found\n";
+#endif
+    }
+  }
+}
+
+string Font_qt::getFamily() const {
+  return _font.family().toStdString();
+}
+
+int Font_qt::getStyle() const {
+  int out = PLAIN;
+  if(_font.bold())   out |= BOLD;
+  if(_font.italic()) out |= ITALIC;
+  return out;
+}
+
+QFont Font_qt::getQFont() const {
+  return _font;
+}
+
+float Font_qt::getSize() const {
+  return _font.pointSizeF();
+}
+
+sptr<Font> Font_qt::deriveFont(int style) const {
+  return sptr<Font>(new Font_qt(getFamily(), style, getSize()));
+}
+
+bool Font_qt::operator==(const Font& ft) const {
+  const Font_qt& o = static_cast<const Font_qt&>(ft);
+
+  return getFamily()==o.getFamily() && getSize()==o.getSize() &&
+    getStyle()==o.getStyle();
+}
+
+bool Font_qt::operator!=(const Font& ft) const {
+  return !(*this == ft);
+}
+
+Font* Font::create(const string& file, float size) {
+  return new Font_qt(file, size);
+}
+
+sptr<Font> Font::_create(const string& name, int style, float size) {
+  return sptr<Font>(new Font_qt(name, style, size));
+}
+
+/**************************************************************************************************/
+
+TextLayout_qt::TextLayout_qt(const wstring& src, const sptr<Font_qt>& f) :
+  _font(f->getQFont()),
+  _text(wstring_to_QString(src))
+{
+}
+
+void TextLayout_qt::getBounds(_out_ Rect& r) {
+  QFontMetricsF fm(_font);
+  QRectF br(fm.boundingRect(_text));
+
+  r.x = br.left();
+  r.y = br.top();
+  r.w = br.width();
+  r.h = br.height();
+}
+
+void TextLayout_qt::draw(Graphics2D& g2, float x, float y) {
+  Graphics2D_qt& g = static_cast<Graphics2D_qt&>(g2);
+  g.getQPainter()->setFont(_font);
+  g.getQPainter()->drawText(QPointF(x, y), _text);
+}
+
+sptr<TextLayout> TextLayout::create(const wstring& src, const sptr<Font>& font) {
+  sptr<Font_qt> f = static_pointer_cast<Font_qt>(font);
+  return sptr<TextLayout>(new TextLayout_qt(src, f));
+}
+
+/**************************************************************************************************/
+
+Font_qt Graphics2D_qt::_default_font("SansSerif", PLAIN, 20.f);
+
+Graphics2D_qt::Graphics2D_qt(QPainter* painter)
+    : _painter(painter) {
+  _sx = _sy = 1.f;
+  setColor(BLACK);
+  setStroke(Stroke());
+  setFont(&_default_font);
+}
+
+QPainter* Graphics2D_qt::getQPainter() const {
+  return _painter;
+}
+
+QBrush Graphics2D_qt::getQBrush() const {
+  return QBrush(QColor(color_r(_color), color_g(_color),
+                       color_b(_color), color_a(_color)));
+}
+
+void Graphics2D_qt::setPen() {
+
+  QBrush brush(getQBrush());
+
+  Qt::PenCapStyle cap;
+  switch (_stroke.cap) {
+  case CAP_ROUND:
+    cap = Qt::RoundCap;
+    break;
+  case CAP_SQUARE:
+    cap = Qt::SquareCap;
+    break;
+  case CAP_BUTT:
+  default:
+    cap = Qt::FlatCap;
+    break;
+  }
+
+  Qt::PenJoinStyle join;
+  switch (_stroke.join) {
+  case JOIN_BEVEL:
+    join = Qt::BevelJoin;
+    break;
+  case JOIN_ROUND:
+    join = Qt::RoundJoin;
+    break;
+  case JOIN_MITER:
+  default:
+    join = Qt::MiterJoin;
+    break;
+  }
+
+  QPen pen(brush, _stroke.lineWidth, Qt::SolidLine, cap, join);
+  pen.setMiterLimit(_stroke.miterLimit);
+  _painter->setPen(pen);
+}
+
+void Graphics2D_qt::setColor(color c) {
+  _color = c;
+  setPen();
+}
+
+color Graphics2D_qt::getColor() const {
+  return _color;
+}
+
+void Graphics2D_qt::setStroke(const Stroke& s) {
+  _stroke = s;
+  setPen();
+}
+
+const Stroke& Graphics2D_qt::getStroke() const {
+  return _stroke;
+}
+
+void Graphics2D_qt::setStrokeWidth(float w) {
+  _stroke.lineWidth = w;
+  setPen();
+}
+
+const Font* Graphics2D_qt::getFont() const {
+  return _font;
+}
+
+void Graphics2D_qt::setFont(const Font* font) {
+  _font = static_cast<const Font_qt*>(font);
+}
+
+void Graphics2D_qt::translate(float dx, float dy) {
+  //qInfo() << "translate" << dx << dy;
+  _painter->translate(dx, dy);
+}
+
+void Graphics2D_qt::scale(float sx, float sy) {
+  //qInfo() << "scale" << sx << sy;
+  _sx *= sx;
+  _sy *= sy;
+  _painter->scale(sx, sy);
+}
+
+void Graphics2D_qt::rotate(float angle) {
+  //qInfo() << "rotate" << angle;
+  _painter->rotate(qRadiansToDegrees(angle));
+}
+
+void Graphics2D_qt::rotate(float angle, float px, float py) {
+
+  //qInfo() << "translate" << px << py << "rotate" << angle;
+  _painter->translate(px, py);
+  _painter->rotate(qRadiansToDegrees(angle));
+  _painter->translate(-px, -py);
+}
+
+void Graphics2D_qt::reset() {
+  _painter->setTransform(QTransform());
+  _sx = _sy = 1.f;
+}
+
+float Graphics2D_qt::sx() const {
+  return _sx;
+}
+
+float Graphics2D_qt::sy() const {
+  return _sy;
+}
+
+void Graphics2D_qt::drawChar(wchar_t c, float x, float y) {
+  wstring str = {c};
+  drawText(str, x, y);
+}
+
+void Graphics2D_qt::drawText(const wstring& t, float x, float y) {
+
+  _painter->setFont(_font->getQFont());
+
+  QString text = wstring_to_QString(t);
+  //qInfo() << "text" << x << y << text << text.toLocal8Bit();
+  //for(size_t i=0; i<t.size(); ++i)
+  //  qInfo() << 'v' << int(t[i]);
+
+  _painter->drawText(QPointF(x, y), text);
+}
+
+void Graphics2D_qt::drawLine(float x1, float y1, float x2, float y2) {
+  _painter->drawLine(QPointF(x1, y1), QPointF(x2, y2));
+}
+
+void Graphics2D_qt::drawRect(float x, float y, float w, float h) {
+  _painter->drawRect(QRectF(x, y, w, h));
+}
+
+void Graphics2D_qt::fillRect(float x, float y, float w, float h) {
+  _painter->fillRect(QRectF(x, y, w, h), getQBrush());
+}
+
+void Graphics2D_qt::drawRoundRect(float x, float y, float w, float h, float rx, float ry) {
+  _painter->drawRoundedRect(QRectF(x, y, w, h), rx, ry);
+}
+
+void Graphics2D_qt::fillRoundRect(float x, float y, float w, float h, float rx, float ry) {
+  _painter->setPen(QPen(Qt::NoPen));
+  _painter->setBrush(getQBrush());
+
+  _painter->drawRoundedRect(QRectF(x, y, w, h), rx, ry);
+
+  setPen();
+  _painter->setBrush(QBrush());
+}
+
+
+/**************************************************************************************************/
+
+
+#endif

--- a/src/platform/qt/graphic_qt.h
+++ b/src/platform/qt/graphic_qt.h
@@ -1,48 +1,42 @@
 #include "config.h"
 
-#if defined(BUILD_WIN32) && !defined(MEM_CHECK)
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
 
-#ifndef GRAPHIC_WIN32_H_INCLUDED
-#define GRAPHIC_WIN32_H_INCLUDED
+#ifndef GRAPHIC_QT_H_INCLUDED
+#define GRAPHIC_QT_H_INCLUDED
 
-#include "common.h"
+#include <string>
 #include "graphic/graphic.h"
 
-using namespace std;
-using namespace tex;
-
-namespace Gdiplus {
-
-class Font;
-class FontFamily;
-class Graphics;
-class Pen;
-class Brush;
-class SolidBrush;
-class StringFormat;
-class Bitmap;
-
-}  // namespace Gdiplus
+#include <QBrush>
+#include <QFont>
+#include <QMap>
+#include <QPainter>
+#include <QString>
 
 namespace tex {
 
-class Font_win32 : public Font {
+// remove a null byte off end of QString
+QString wstring_to_QString(const std::wstring& ws);
+
+class Font_qt : public Font {
+
 private:
-  static const Gdiplus::FontFamily* _serif;
-  static const Gdiplus::FontFamily* _sansserif;
+  QFont _font;
 
-  float _size;
-
-  Font_win32();
+  static QMap<QString, QString> _loaded_families;
 
 public:
-  int _style;
-  sptr<Gdiplus::Font> _typeface;
-  const Gdiplus::FontFamily* _family;
 
-  Font_win32(const string& name, int style, float size);
+  Font_qt(const std::string& family = "", int style = PLAIN, float size = 1.f);
 
-  Font_win32(const string& file, float size);
+  Font_qt(const std::string& file, float size);
+
+  std::string getFamily() const;
+
+  int getStyle() const;
+
+  QFont getQFont() const;
 
   virtual float getSize() const override;
 
@@ -52,50 +46,46 @@ public:
 
   virtual bool operator!=(const Font& f) const override;
 
-  virtual ~Font_win32();
+  virtual ~Font_qt() {};
 
-  static int convertStyle(int style);
 };
+
 
 /**************************************************************************************************/
 
-class TextLayout_win32 : public TextLayout {
+class TextLayout_qt : public TextLayout {
 private:
-  sptr<Font_win32> _font;
-  wstring _txt;
+  QFont _font;
+  QString _text;
 
 public:
-  static const Gdiplus::StringFormat* _format;
-  static Gdiplus::Graphics* _g;
-  static Gdiplus::Bitmap* _img;
+  TextLayout_qt(const wstring& src, const sptr<Font_qt>& font);
 
-  TextLayout_win32(const wstring& src, const sptr<Font_win32>& font);
-
-  virtual void getBounds(_out_ Rect& bounds) override;
+  virtual void getBounds(_out_ Rect& r) override;
 
   virtual void draw(Graphics2D& g2, float x, float y) override;
 };
 
 /**************************************************************************************************/
 
-class Graphics2D_win32 : public Graphics2D {
+class Graphics2D_qt : public Graphics2D {
 private:
-  static const Gdiplus::StringFormat* _format;
-  static const Font* _defaultFont;
+  static Font_qt _default_font;
+
+  QPainter* _painter;
 
   color _color;
-  const Font* _font;
   Stroke _stroke;
-  Gdiplus::Graphics* _g;
-  Gdiplus::Pen* _pen;
-  Gdiplus::SolidBrush* _brush;
-
+  const Font_qt* _font;
   float _sx, _sy;
 
-public:
-  Graphics2D_win32(Gdiplus::Graphics* g);
+  void setPen();
+  QBrush getQBrush() const;
 
-  ~Graphics2D_win32();
+public:
+  Graphics2D_qt(QPainter* painter);
+
+  QPainter* getQPainter() const;
 
   virtual void setColor(color c) override;
 
@@ -127,9 +117,9 @@ public:
 
   virtual void drawChar(wchar_t c, float x, float y) override;
 
-  virtual void drawText(const wstring& c, float x, float y) override;
+  virtual void drawText(const wstring& t, float x, float y) override;
 
-  virtual void drawLine(float x1, float y1, float x2, float y2) override;
+  virtual void drawLine(float x, float y1, float x2, float y2) override;
 
   virtual void drawRect(float x, float y, float w, float h) override;
 
@@ -140,7 +130,7 @@ public:
   virtual void fillRoundRect(float x, float y, float w, float h, float rx, float ry) override;
 };
 
-}  // namespace tex
+}
 
-#endif  // GRAPHIC_WIN32_H_INCLUDED
-#endif
+#endif   // GRAPHIC_QT_H_INCLUDED
+#endif   // defined(BUILD_QT) && !defined(MEM_CHECK)

--- a/src/samples/gtkmm_main.cpp
+++ b/src/samples/gtkmm_main.cpp
@@ -1,6 +1,6 @@
 #include "config.h"
 
-#if defined(__OS_Unix_like_PC__) && !defined(MEM_CHECK)
+#if defined(BUILD_GTK) && !defined(MEM_CHECK)
 
 #include "latex.h"
 #include "platform/cairo/graphic_cairo.h"

--- a/src/samples/qt_main.cpp
+++ b/src/samples/qt_main.cpp
@@ -1,0 +1,23 @@
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
+
+#include "latex.h"
+#include "samples.h"
+
+#include "qt_mainwindow.h"
+
+#include <QApplication>
+
+int main(int argc, char **argv)
+{
+  QApplication app(argc, argv);
+
+  LaTeX::init();
+  MainWindow mainwin;
+  mainwin.show();
+  int retn = app.exec();
+
+  LaTeX::release();
+  return retn;
+}
+
+#endif

--- a/src/samples/qt_mainwindow.cpp
+++ b/src/samples/qt_mainwindow.cpp
@@ -1,0 +1,98 @@
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
+
+#include <string>
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSplitter>
+#include <QString>
+#include <QVBoxLayout>
+
+#include "qt_mainwindow.h"
+#include "moc_qt_mainwindow.cpp"
+
+using namespace std;
+
+MainWindow::MainWindow(QWidget* parent)
+  : QWidget(parent)
+{
+  int text_size = 20;
+
+  // main layout for window
+  QHBoxLayout* layout = new QHBoxLayout;
+
+  // splitter separates left from right
+  QSplitter* splitter = new QSplitter;
+  layout->addWidget(splitter);
+
+  // the TeX widget is on the left
+  _texwidget = new TeXWidget(nullptr, text_size);
+  _texwidget->setMinimumWidth(400);
+
+  // these are the widgets on the right side
+  // want an editor at the top and controls at bottom
+  QWidget* right = new QWidget;
+  QVBoxLayout* rlayout = new QVBoxLayout;
+  right->setLayout(rlayout);
+  _textedit = new QTextEdit;
+  rlayout->addWidget(_textedit);
+
+  // these are the controls which go at the bottom right
+  QWidget* controls = new QWidget;
+  QHBoxLayout* clayout = new QHBoxLayout;
+  controls->setLayout(clayout);
+
+  QLabel* label1 = new QLabel("Change text size:");
+  _sizespin = new QSpinBox;
+  _sizespin->setValue(text_size);
+  _sizespin->setMinimum(1);
+  QPushButton* next = new QPushButton("Next example");
+  QPushButton* render = new QPushButton("Rendering");
+  QPushButton* save = new QPushButton("Save as SVG");
+  clayout->addWidget(label1);
+  clayout->addWidget(_sizespin);
+  clayout->addWidget(next);
+  clayout->addWidget(render);
+  clayout->addWidget(save);
+
+  rlayout->addWidget(controls);
+
+  splitter->addWidget(_texwidget);
+  splitter->addWidget(right);
+
+  setLayout(layout);
+
+  QObject::connect(next, &QPushButton::clicked,
+                   this, &MainWindow::nextClicked);
+  QObject::connect(render, &QPushButton::clicked,
+                   this, &MainWindow::renderClicked);
+  QObject::connect(save, &QPushButton::clicked,
+                   this, &MainWindow::saveClicked);
+  QObject::connect(_sizespin, SIGNAL(valueChanged(int)),
+                    this, SLOT(fontSizeChanged(int)));
+}
+
+void MainWindow::fontSizeChanged(int size)
+{
+  _texwidget->setTextSize(size);
+}
+
+void MainWindow::nextClicked()
+{
+  auto sample = _samples.next();
+  _textedit->setText(QString::fromStdWString(sample));
+  _texwidget->setLaTeX(sample);
+}
+
+void MainWindow::renderClicked()
+{
+  QString text = _textedit->toPlainText();
+  _texwidget->setLaTeX(text.toStdWString());
+}
+
+void MainWindow::saveClicked()
+{
+}
+
+#endif

--- a/src/samples/qt_mainwindow.h
+++ b/src/samples/qt_mainwindow.h
@@ -1,0 +1,35 @@
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
+
+#ifndef QT_MAINWINDOW_H
+#define QT_MAINWINDOW_H
+
+#include "samples.h"
+#include "qt_texwidget.h"
+
+#include <QWidget>
+#include <QTextEdit>
+#include <QSpinBox>
+
+class MainWindow : public QWidget
+{
+  Q_OBJECT
+
+public:
+  MainWindow(QWidget* parent=nullptr);
+
+protected slots:
+  void nextClicked();
+  void renderClicked();
+  void saveClicked();
+  void fontSizeChanged(int size);
+
+protected:
+  TeXWidget* _texwidget;
+  QTextEdit* _textedit;
+  QSpinBox* _sizespin;
+
+  Samples _samples;
+};
+
+#endif
+#endif

--- a/src/samples/qt_texwidget.cpp
+++ b/src/samples/qt_texwidget.cpp
@@ -1,0 +1,75 @@
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
+
+#include "qt_texwidget.h"
+
+TeXWidget::TeXWidget(QWidget* parent, float text_size)
+  : QWidget(parent),
+    _render(nullptr),
+    _text_size(text_size),
+    _padding(20)
+{
+  QPalette pal = palette();
+  pal.setColor(QPalette::Background, Qt::white);
+  setPalette(pal);
+}
+
+TeXWidget::~TeXWidget()
+{
+  if (_render != nullptr) delete _render;
+}
+
+float TeXWidget::getTextSize()
+{
+  return _text_size;
+}
+
+void TeXWidget::setTextSize(float size)
+{
+  if(size == _text_size) return;
+  _text_size = size;
+  if(_render != nullptr) {
+    _render->setTextSize(_text_size);
+    update();
+  }
+}
+
+void TeXWidget::setLaTeX(const wstring& latex)
+{
+  if (_render != nullptr) delete _render;
+
+  _render = LaTeX::parse(
+        latex,
+        width() - _padding * 2,
+        _text_size,
+        _text_size / 3.f,
+        0xff424242);
+  update();
+}
+
+bool TeXWidget::isRenderDisplayed()
+{
+  return _render != nullptr;
+}
+
+int TeXWidget::getRenderWidth()
+{
+  return _render == nullptr ? 0 : _render->getWidth() + _padding * 2;
+}
+
+int TeXWidget::getRenderHeight()
+{
+  return _render == nullptr ? 0 : _render->getHeight() + _padding * 2;
+}
+
+void TeXWidget::paintEvent(QPaintEvent* event)
+{
+  if(_render != nullptr) {
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    Graphics2D_qt g2(&painter);
+    _render->draw(g2, _padding, _padding);
+  }
+}
+
+
+#endif

--- a/src/samples/qt_texwidget.h
+++ b/src/samples/qt_texwidget.h
@@ -1,0 +1,34 @@
+#include "config.h"
+
+#if defined(BUILD_QT) && !defined(MEM_CHECK)
+
+#ifndef QT_TEXWIDGET_H
+#define QT_TEXWIDGET_H
+
+#include "platform/qt/graphic_qt.h"
+#include "latex.h"
+
+#include <QWidget>
+
+class TeXWidget : public QWidget
+{
+ public:
+  TeXWidget(QWidget* parent = nullptr, float text_size=20.f);
+  virtual ~TeXWidget();
+  float getTextSize();
+
+  void setTextSize(float size);
+  void setLaTeX(const wstring& latex);
+  bool isRenderDisplayed();
+  int getRenderWidth();
+  int getRenderHeight();
+  void paintEvent(QPaintEvent* event);
+
+ private:
+  TeXRender* _render;
+  float _text_size;
+  int _padding;
+};
+
+#endif
+#endif

--- a/src/samples/win32_main.cpp
+++ b/src/samples/win32_main.cpp
@@ -1,4 +1,6 @@
-#if defined(__OS_Windows__) && !defined(MEM_CHECK)
+#include "config.h"
+
+#if defined(BUILD_WIN32) && !defined(MEM_CHECK)
 
 #include "latex.h"
 #include "platform/gdi_win/graphic_win32.h"


### PR DESCRIPTION
Please find attached my initial Qt supporting version. For more details of problems see bug #26  . Also, this doesn't yet support the command line mode. The SVG button does nothing. The docs could be improved.

I've changed the build system to support Qt on more than one platform. I tried to do this cleanly. To build cmake needs a `-DQT=ON` option. I also reduced the cmake minimum version, as it seems to work ok on Ubuntu with this version (they're not shipping the currently required version).
