### PR TITLE
Get underlying ptr of shared_ptr without dereferencing.

### DIFF
--- a/src/atom/atom_basic.cpp
+++ b/src/atom/atom_basic.cpp
@@ -480,7 +480,7 @@ sptr<Box> RowAtom::createBox(_out_ TeXEnvironment& env) {
     // i.e. for formula: $+ e - f$, the plus sign should be traded as an ordinary type
     sptr<Atom> nextAtom(nullptr);
     if (i < e) nextAtom = _elements[i + 1];
-    change2Ord(&(*atom), &(*_previousAtom), &(*nextAtom));
+    change2Ord(atom.get(), _previousAtom.get(), nextAtom.get());
     // check for ligature or kerning
     float kern = 0;
     while (i < e && atom->getRightType() == TYPE_ORDINARY && atom->isCharSymbol()) {


### PR DESCRIPTION
Over at blackhole89/notekit#60, we were struggling with a crash due to a failed assertion under `atom_basic.cpp:483`. It turns out that trick used there to get the address from a shared_ptr does not work when _GLIBCXX_ASSERTIONS is defined and the pointer is NULL (as is the case with _previousAtom in that line at first). Indeed, if you check bits/shared_ptr_base.h, there's an assertion in the relevant operator* that the dereferenced pointer should not be NULL, regardless of the valid-ish use case of immediately taking its address again. I think the intended way of getting the underlying ptr is to use .get() instead.

I've only fixed the instance we bumped up against; if there are other places in the code with the `&(*smartptr)` pattern, they probably should changed in the same way too.