### PR TITLE
initial support of resource detection &  meson demo target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('clatexmath', 'cpp',
 	version : '0.0.1',
-	default_options : ['buildtype=release', 'warning_level=3', 'cpp_std=c++11']
+	default_options : ['buildtype=release', 'warning_level=3', 'cpp_std=c++17']
 )
 
 deps = [
@@ -91,104 +91,111 @@ src = [
 	'src/xml/tinyxml2.cpp'
 ]
 clatexmath_inc = include_directories('src')
+if get_option('TARGET_LIB')
+	clatexmath_lib = library('clatexmath', src,
+		include_directories: clatexmath_inc,
+		dependencies: deps,
+		version: meson.project_version(),
+		soversion: 1,
+		install: true
+	)
+	install_headers([
+		'src/common.h',
+		'src/config.h',
+		'src/latex.h',
+		'src/render.h',
+	], subdir: 'clatexmath')
+	install_headers([
+		'src/atom/atom.h',
+		'src/atom/atom_basic.h',
+		'src/atom/atom_impl.h',
+		'src/atom/box.h',
+	], subdir: 'clatexmath/atom')
+	install_headers([
+		'src/core/core.h',
+		'src/core/formula.h',
+		'src/core/macro.h',
+		'src/core/macro_impl.h',
+		'src/core/parser.h',
+	], subdir: 'clatexmath/core')
+	install_headers([
+		'src/fonts/alphabet.h',
+		'src/fonts/font_basic.h',
+		'src/fonts/font_info.h',
+		'src/fonts/font_reg.h',
+		'src/fonts/fonts.h',
+		'src/fonts/symbol_reg.h',
+		'src/fonts/tex_font.h',
+	], subdir: 'clatexmath/fonts')
+	install_headers([
+		'src/graphic/graphic.h',
+		'src/graphic/graphic_basic.h',
+	], subdir: 'clatexmath/graphic')
+	install_headers([
+		'src/platform/cairo/graphic_cairo.h',
+	], subdir: 'clatexmath/platform/cairo')
+	install_headers([
+		'src/platform/gdi_win/graphic_win32.h',
+	], subdir: 'clatexmath/platform/gdi_win')
+	install_headers([
+		'src/platform/qt/graphic_qt.h',
+	], subdir: 'clatexmath/platform/qt')
+	install_headers([
+		'src/res/font_def.res.h',
+		'src/res/symbol_def.res.h',
+	], subdir: 'clatexmath/res')
+	install_headers([
+		'src/res/parser/font_parser.h',
+		'src/res/parser/formula_parser.h',
+	], subdir: 'clatexmath/res/parser')
+	install_headers([
+		'src/res/reg/builtin_font_reg.h',
+		'src/res/reg/builtin_syms_reg.h',
+	], subdir: 'clatexmath/res/reg')
+	install_headers([
+		'src/samples/qt_mainwindow.h',
+		'src/samples/qt_texwidget.h',
+		'src/samples/samples.h',
+	], subdir: 'clatexmath/samples')
+	install_headers([
+		'src/utils/constants.h',
+		'src/utils/exceptions.h',
+		'src/utils/indexed_arr.h',
+		'src/utils/log.h',
+		'src/utils/nums.h',
+		'src/utils/string_utils.h',
+		'src/utils/utf.h',
+	], subdir: 'clatexmath/utils')
+	install_headers([
+		'src/xml/tinyxml2.h',
+	], subdir: 'clatexmath/xml')
 
-clatexmath_lib = library('clatexmath', src,
-	include_directories: clatexmath_inc,
-	dependencies: deps,
-	version: meson.project_version(),
-	soversion: 0,
-	install: true
-)
+	import('pkgconfig').generate(
+		libraries : clatexmath_lib,
+		version : meson.project_version(),
+		name : 'clatexmath',
+		filebase : 'clatexmath',
+		subdirs: 'clatexmath',
+		description : 'A dynamic, cross-platform, and embeddable LaTeX rendering library'
+	)
+
+	latex_dep  = declare_dependency(
+		link_with : clatexmath_lib,
+		include_directories : clatexmath_inc,
+		version : meson.project_version()
+	)
+endif
+
+if get_option('TARGET_DEMO')
+	executable('clatexmath', src,
+		include_directories: clatexmath_inc,
+		dependencies: deps,
+		install: true
+	)
+endif
 
 
 install_subdir('res/fonts', install_dir: get_option('datadir')/'clatexmath')
 install_subdir('res/greek', install_dir: get_option('datadir')/'clatexmath')
 install_subdir('res/cyrillic', install_dir: get_option('datadir')/'clatexmath')
 install_data(['res/RES_README', 'res/SAMPLES.tex'])
-
-
-install_headers([
-	'src/common.h',
-	'src/config.h',
-	'src/latex.h',
-	'src/render.h',
-], subdir: 'clatexmath')
-install_headers([
-	'src/atom/atom.h',
-	'src/atom/atom_basic.h',
-	'src/atom/atom_impl.h',
-	'src/atom/box.h',
-], subdir: 'clatexmath/atom')
-install_headers([
-	'src/core/core.h',
-	'src/core/formula.h',
-	'src/core/macro.h',
-	'src/core/macro_impl.h',
-	'src/core/parser.h',
-], subdir: 'clatexmath/core')
-install_headers([
-	'src/fonts/alphabet.h',
-	'src/fonts/font_basic.h',
-	'src/fonts/font_info.h',
-	'src/fonts/font_reg.h',
-	'src/fonts/fonts.h',
-	'src/fonts/symbol_reg.h',
-	'src/fonts/tex_font.h',
-], subdir: 'clatexmath/fonts')
-install_headers([
-	'src/graphic/graphic.h',
-	'src/graphic/graphic_basic.h',
-], subdir: 'clatexmath/graphic')
-install_headers([
-	'src/platform/cairo/graphic_cairo.h',
-], subdir: 'clatexmath/platform/cairo')
-install_headers([
-	'src/platform/gdi_win/graphic_win32.h',
-], subdir: 'clatexmath/platform/gdi_win')
-install_headers([
-	'src/platform/qt/graphic_qt.h',
-], subdir: 'clatexmath/platform/qt')
-install_headers([
-	'src/res/font_def.res.h',
-	'src/res/symbol_def.res.h',
-], subdir: 'clatexmath/res')
-install_headers([
-	'src/res/parser/font_parser.h',
-	'src/res/parser/formula_parser.h',
-], subdir: 'clatexmath/res/parser')
-install_headers([
-	'src/res/reg/builtin_font_reg.h',
-	'src/res/reg/builtin_syms_reg.h',
-], subdir: 'clatexmath/res/reg')
-install_headers([
-	'src/samples/qt_mainwindow.h',
-	'src/samples/qt_texwidget.h',
-	'src/samples/samples.h',
-], subdir: 'clatexmath/samples')
-install_headers([
-	'src/utils/constants.h',
-	'src/utils/exceptions.h',
-	'src/utils/indexed_arr.h',
-	'src/utils/log.h',
-	'src/utils/nums.h',
-	'src/utils/string_utils.h',
-	'src/utils/utf.h',
-], subdir: 'clatexmath/utils')
-install_headers([
-	'src/xml/tinyxml2.h',
-], subdir: 'clatexmath/xml')
-
-import('pkgconfig').generate(
-	libraries : clatexmath_lib,
-	version : meson.project_version(),
-	name : 'clatexmath',
-	filebase : 'clatexmath',
-	subdirs: 'clatexmath',
-	description : 'A dynamic, cross-platform, and embeddable LaTeX rendering library'
-)
-
-latex_dep  = declare_dependency(
-	link_with : clatexmath_lib,
-	include_directories : clatexmath_inc,
-	version : meson.project_version()
-)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('clatexmath', 'cpp',
-	version : '0.0.1',
+	version : '0.0.2',
 	default_options : ['buildtype=release', 'warning_level=3', 'cpp_std=c++17']
 )
 
@@ -96,7 +96,7 @@ if get_option('TARGET_LIB')
 		include_directories: clatexmath_inc,
 		dependencies: deps,
 		version: meson.project_version(),
-		soversion: 1,
+		soversion: 0,
 		install: true
 	)
 	install_headers([

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('TARGET_LIB', type : 'boolean', value : true)
+option('TARGET_DEMO', type : 'boolean', value : false)

--- a/src/latex.cpp
+++ b/src/latex.cpp
@@ -13,8 +13,57 @@ string tex::RES_BASE = "res";
 TeXFormula*       LaTeX::_formula = nullptr;
 TeXRenderBuilder* LaTeX::_builder = nullptr;
 
-void LaTeX::init(const string& res_root_path) {
-  RES_BASE = res_root_path;
+string LaTeX::queryResourceLocation(string& custom_path) {
+    queue<string> paths;
+	paths.push(custom_path);
+
+	// checks if XDG_DATA_HOME exists. If it does, it pushes it to potential paths.
+	char* userdata = getenv("XDG_DATA_HOME");
+	if (userdata != NULL && userdata != "") {
+		paths.push(string(userdata));
+	}
+	delete userdata;
+
+	// checks if XDG_DATA_DIRS is set. If it is, it splits XDG_DATA_DIRS at : and pushes each part of it to potential paths.
+	char* xdg = getenv("XDG_DATA_DIRS");
+	if (xdg != NULL && xdg != "") {
+		stringstream xdg_paths(xdg);
+		string xdg_path;
+		while (getline(xdg_paths, xdg_path, ':')) {
+			paths.push(xdg_path);
+		}
+	}
+
+	// checks if HOME env var is unset. if it isn't it pushes ~/.local/share/clatexmath to potential paths.
+	char* home = getenv("HOME");
+	if (home != NULL && home != "") {
+		char* userdata_fallback;
+		asprintf(&userdata_fallback, "%s/.local/share/clatexmath/", home);
+		paths.push(string(userdata_fallback));
+		delete userdata_fallback;
+	}
+	paths.push("/usr/share/clatexmath/");
+	paths.push("/usr/local/share/clatexmath/");
+
+	// goes through the list of potential paths. if it finds a path that contains .clatexmath-res_root, it returns it. Otherwise I'll throw an error.
+	while (paths.size() > 0) {
+		filesystem::path p = paths.front();
+		p.append(".clatexmath-res_root");
+		if (filesystem::exists(p)) {
+			p.remove_filename();
+			return p.u8string();
+		}
+		paths.pop();
+	}
+    throw "resource location was not found";
+}
+
+void LaTeX::init(string res_root_path) {
+  try {
+    RES_BASE = queryResourceLocation(res_root_path);
+  } catch (const std::string& e) {
+    throw e;
+  }
   if (_formula != nullptr) return;
 
   NewCommandMacro::_init_();

--- a/src/latex.h
+++ b/src/latex.h
@@ -7,6 +7,9 @@
 #include "render.h"
 
 #include <string>
+#include <filesystem>
+#include <queue>
+#include <sstream>
 
 using namespace std;
 using namespace tex;
@@ -19,7 +22,8 @@ class LaTeX {
 private:
   static TeXFormula* _formula;
   static TeXRenderBuilder* _builder;
-
+protected:
+  static string queryResourceLocation(string& custom_path);
 public:
   /**
    * Initialize TeX context with given root path of the TeX resources
@@ -27,7 +31,8 @@ public:
    * @param res_root_path
    *      root path of the resources, default is 'res'
    */
-  static void init(const string& res_root_path = "res");
+
+  static void init(string res_root_path = "res");
 
   /**
    * Get the root path of the "TeX resources"


### PR DESCRIPTION
- I don't like that it throws a string if it doesn't find a resource location. I'd prefer to use somthing similar to Rust's `std::Result<std::String, Box<dyn std::error::Error>>` but I'm unable to figure out how enums work in c++. Please take a look at it.

- bumped version from 0.0.1 to 0.0.2
- meson can now build the demo aswell. (`meson _build -DTARGET_DEMO=true -DTARGET_LIB=false`).

Should close #38 