### PR TITLE
Legacy GCC Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,20 @@ endif()
 # check for lstdc++fs
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-     set(CXX_FILESYSTEM_LIBRARIES "stdc++fs")
+	if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9)
+    	set(CXX_FILESYSTEM_LIBRARIES "stdc++fs")
+	endif()
+    # check for older gcc
+    if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 8)
+		set("EXPERIMENTAL_FS" ON)
+    endif()
 endif()
+
+# configure
+configure_file(
+	"src/def.h.cmake.in"
+	"src/def.h"
+)
 
 # copy res dir
 

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,13 @@ deps = [
 	dependency('gtksourceviewmm-3.0')
 ]
 
+# GCC versions earlier than 9 require linking with stdc++fs to use
+# std::filesystem functionality.
+cc = meson.get_compiler('cpp')
+if cc.get_id() == 'gcc' and cc.version().version_compare('<9')
+    deps += [ cc.find_library('stdc++fs') ]
+endif
+
 add_global_arguments('-DBUILD_GTK', language : 'cpp')
 
 src = [

--- a/meson.build
+++ b/meson.build
@@ -9,12 +9,22 @@ deps = [
 	dependency('gtksourceviewmm-3.0')
 ]
 
+conf = configuration_data()
+
 # GCC versions earlier than 9 require linking with stdc++fs to use
 # std::filesystem functionality.
 cc = meson.get_compiler('cpp')
 if cc.get_id() == 'gcc' and cc.version().version_compare('<9')
     deps += [ cc.find_library('stdc++fs') ]
 endif
+if cc.get_id() == 'gcc' and cc.version().version_compare('<8')
+    conf.set('EXPERIMENTAL_FS', true)
+endif
+
+configure_file(input : 'src/def.h.meson.in',
+	output : 'def.h',
+	configuration : conf
+)
 
 add_global_arguments('-DBUILD_GTK', language : 'cpp')
 

--- a/src/def.h.cmake.in
+++ b/src/def.h.cmake.in
@@ -1,0 +1,1 @@
+#cmakedefine EXPERIMENTAL_FS

--- a/src/def.h.meson.in
+++ b/src/def.h.meson.in
@@ -1,0 +1,1 @@
+#mesondefine EXPERIMENTAL_FS

--- a/src/latex.h
+++ b/src/latex.h
@@ -7,11 +7,19 @@
 #include "render.h"
 
 #include <string>
-#include <filesystem>
 #include <queue>
 #include <sstream>
 
 using namespace std;
+
+#include "def.h"
+#ifdef EXPERIMENTAL_FS
+#include <experimental/filesystem>
+namespace filesystem=experimental::filesystem;
+#else
+#include <filesystem>
+#endif
+
 using namespace tex;
 
 namespace tex {


### PR DESCRIPTION
This MR adds:
- gcc that is lower than version nine is linked against `stdc++fs`
- gcc that is lower than version eight will use `experimental/filesystem` instead of `filesystem`

Please check the cmake files. I hate cmake - unsure if this works correctly 