### PR TITLE
fix compilation for Qt (namespaces)

### DIFF
--- a/src/platform/qt/graphic_qt.cpp
+++ b/src/platform/qt/graphic_qt.cpp
@@ -28,7 +28,7 @@ QMap<QString, QString> Font_qt::_loaded_families;
 
 namespace tex {
 // Some wstrings arrive with a \0 at end, so we remove when converting
-QString wstring_to_QString(const wstring& ws)
+QString wstring_to_QString(const std::wstring& ws)
 {
   QString out = QString::fromStdWString(ws);
   auto index = out.indexOf('\0');
@@ -130,7 +130,7 @@ sptr<Font> Font::_create(const string& name, int style, float size) {
 
 /**************************************************************************************************/
 
-TextLayout_qt::TextLayout_qt(const wstring& src, const sptr<Font_qt>& f) :
+TextLayout_qt::TextLayout_qt(const std::wstring& src, const sptr<Font_qt>& f) :
   _font(f->getQFont()),
   _text(wstring_to_QString(src))
 {
@@ -152,7 +152,7 @@ void TextLayout_qt::draw(Graphics2D& g2, float x, float y) {
   g.getQPainter()->drawText(QPointF(x, y), _text);
 }
 
-sptr<TextLayout> TextLayout::create(const wstring& src, const sptr<Font>& font) {
+sptr<TextLayout> TextLayout::create(const std::wstring& src, const sptr<Font>& font) {
   sptr<Font_qt> f = static_pointer_cast<Font_qt>(font);
   return sptr<TextLayout>(new TextLayout_qt(src, f));
 }
@@ -285,11 +285,11 @@ float Graphics2D_qt::sy() const {
 }
 
 void Graphics2D_qt::drawChar(wchar_t c, float x, float y) {
-  wstring str = {c};
+  std::wstring str = {c};
   drawText(str, x, y);
 }
 
-void Graphics2D_qt::drawText(const wstring& t, float x, float y) {
+void Graphics2D_qt::drawText(const std::wstring& t, float x, float y) {
 
   _painter->setFont(_font->getQFont());
 

--- a/src/platform/qt/graphic_qt.h
+++ b/src/platform/qt/graphic_qt.h
@@ -59,7 +59,7 @@ private:
   QString _text;
 
 public:
-  TextLayout_qt(const wstring& src, const sptr<Font_qt>& font);
+  TextLayout_qt(const std::wstring& src, const sptr<Font_qt>& font);
 
   virtual void getBounds(_out_ Rect& r) override;
 
@@ -117,7 +117,7 @@ public:
 
   virtual void drawChar(wchar_t c, float x, float y) override;
 
-  virtual void drawText(const wstring& t, float x, float y) override;
+  virtual void drawText(const std::wstring& t, float x, float y) override;
 
   virtual void drawLine(float x, float y1, float x2, float y2) override;
 

--- a/src/samples/gtkmm_main.cpp
+++ b/src/samples/gtkmm_main.cpp
@@ -76,7 +76,7 @@ public:
     }
   }
 
-  void setLaTeX(const wstring& latex) {
+  void setLaTeX(const std::wstring& latex) {
     if (_render != nullptr) delete _render;
 
     _render = LaTeX::parse(
@@ -233,7 +233,7 @@ protected:
   }
 
   void on_rendering_clicked() {
-    wstring x;
+    std::wstring x;
     utf82wide(_tex_editor.get_buffer()->get_text().c_str(), x);
     _tex.setLaTeX(x);
     _save.set_sensitive(_tex.isRenderDisplayed());
@@ -268,7 +268,7 @@ public:
   float _padding = 10.f;
   float _maxWidth = 720.f;
 
-  void generateSingle(const wstring& code, const string& file) {
+  void generateSingle(const std::wstring& code, const string& file) {
     auto r = LaTeX::parse(code, _maxWidth, _textSize, _textSize / 3.f, _foreground);
     const float w = r->getWidth() + _padding * 2;
     const float h = r->getHeight() + _padding * 2;
@@ -301,7 +301,7 @@ public:
       __print(ANSI_COLOR_RED "Error: the option '-output' must be specified\n" ANSI_RESET);
       return 1;
     }
-    wstring code;
+    std::wstring code;
     utf82wide(_input.c_str(), code);
     generateSingle(code, _outputFile);
     return 0;

--- a/src/samples/mem_check_main.cpp
+++ b/src/samples/mem_check_main.cpp
@@ -52,7 +52,7 @@ public:
   }
 };
 
-sptr<TextLayout> TextLayout::create(const wstring& src, const sptr<Font>& font) {
+sptr<TextLayout> TextLayout::create(const std::wstring& src, const sptr<Font>& font) {
   return sptr<TextLayout>(new TextLayout_none());
 }
 
@@ -123,7 +123,7 @@ public:
   void drawChar(wchar_t c, float x, float y) override {
   }
 
-  void drawText(const wstring& c, float x, float y) override {
+  void drawText(const std::wstring& c, float x, float y) override {
   }
 
   void drawLine(float x1, float y1, float x2, float y2) override {

--- a/src/samples/qt_main.cpp
+++ b/src/samples/qt_main.cpp
@@ -11,12 +11,12 @@ int main(int argc, char **argv)
 {
   QApplication app(argc, argv);
 
-  LaTeX::init();
+  tex::LaTeX::init();
   MainWindow mainwin;
   mainwin.show();
   int retn = app.exec();
 
-  LaTeX::release();
+  tex::LaTeX::release();
   return retn;
 }
 

--- a/src/samples/qt_mainwindow.h
+++ b/src/samples/qt_mainwindow.h
@@ -28,7 +28,7 @@ protected:
   QTextEdit* _textedit;
   QSpinBox* _sizespin;
 
-  Samples _samples;
+  tex::Samples _samples;
 };
 
 #endif

--- a/src/samples/qt_texwidget.cpp
+++ b/src/samples/qt_texwidget.cpp
@@ -2,6 +2,8 @@
 
 #include "qt_texwidget.h"
 
+using namespace tex;
+
 TeXWidget::TeXWidget(QWidget* parent, float text_size)
   : QWidget(parent),
     _render(nullptr),
@@ -33,7 +35,7 @@ void TeXWidget::setTextSize(float size)
   }
 }
 
-void TeXWidget::setLaTeX(const wstring& latex)
+void TeXWidget::setLaTeX(const std::wstring& latex)
 {
   if (_render != nullptr) delete _render;
 

--- a/src/samples/qt_texwidget.h
+++ b/src/samples/qt_texwidget.h
@@ -18,14 +18,14 @@ class TeXWidget : public QWidget
   float getTextSize();
 
   void setTextSize(float size);
-  void setLaTeX(const wstring& latex);
+  void setLaTeX(const std::wstring& latex);
   bool isRenderDisplayed();
   int getRenderWidth();
   int getRenderHeight();
   void paintEvent(QPaintEvent* event);
 
  private:
-  TeXRender* _render;
+  tex::TeXRender* _render;
   float _text_size;
   int _padding;
 };

--- a/src/samples/samples.h
+++ b/src/samples/samples.h
@@ -11,10 +11,12 @@
 
 namespace tex {
 
+using namespace std;
+
 class Samples {
 private:
   int _index;
-  vector<wstring> _samples;
+  vector<std::wstring> _samples;
 
   void readSamples(const string& file = "") {
     string path = file;
@@ -51,9 +53,9 @@ private:
 public:
   Samples(const string& file = "") : _index(0) { readSamples(file); }
 
-  const wstring& next() {
+  const std::wstring& next() {
     if (_index >= _samples.size()) _index = 0;
-    const wstring& x = _samples[_index];
+    const std::wstring& x = _samples[_index];
     _index++;
     return x;
   }

--- a/src/samples/win32_main.cpp
+++ b/src/samples/win32_main.cpp
@@ -147,7 +147,7 @@ void HandleRandom() {
   }
   RECT r;
   GetClientRect(hCanvas, &r);
-  _render = LaTeX::parse(wstring(tex::SAMPLES[idx]), r.right - r.left, _size, _size / 3.f, _color);
+  _render = LaTeX::parse(std::wstring(tex::SAMPLES[idx]), r.right - r.left, _size, _size / 3.f, _color);
   InvalidateRect(hCanvas, NULL, TRUE);
   UpdateWindow(hCanvas);
 }
@@ -161,7 +161,7 @@ void HandleOK() {
   }
   RECT r;
   GetClientRect(hCanvas, &r);
-  _render = LaTeX::parse(wstring(txt), r.right - r.left, _size, _size / 3.f, _color);
+  _render = LaTeX::parse(std::wstring(txt), r.right - r.left, _size, _size / 3.f, _color);
   InvalidateRect(hCanvas, NULL, TRUE);
   UpdateWindow(hCanvas);
   delete[] txt;


### PR DESCRIPTION
Several errors occurs during compilation with MinGW for Qt. This patch fixes them.