### PR TITLE
rewrite CMakeLists.txt for better integration with other projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/Doxyfile
 .vscode/
 prebuilt-scripts/
 .idea
+cmake-build-debug

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/doc
 src/Doxyfile
 .vscode/
 prebuilt-scripts/
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,109 +1,230 @@
 cmake_minimum_required(VERSION 3.16)
 project(LaTeX)
 
+add_library(LaTeX "")
+
 # MSVC Compat
 
 if (MSVC)
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     add_compile_options("/utf-8")
-else()
+else ()
 
-# check if compiler has c++11/c++17 support
+    # check if compiler has c++11/c++17 support
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
 
-# check gcc version
+    # check gcc version
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9)
-        # needs extra lib to use std::filesystem
-    	set(CXX_FILESYSTEM_LIBRARIES "stdc++fs")
-	endif()
-    if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 8)
-        # dose not have full c++17 features
-		set(COMPILER_SUPPORTS_CXX17 OFF)
-    endif()
-endif()
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9)
+            # needs extra lib to use std::filesystem
+            target_link_libraries(LaTeX PUBLIC "stdc++fs")
+        endif ()
+        if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 8)
+            # dose not have full c++17 features
+            set(COMPILER_SUPPORTS_CXX17 OFF)
+        endif ()
+    endif ()
 
-if(COMPILER_SUPPORTS_CXX17)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-elseif(COMPILER_SUPPORTS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no c++11 support. Please use a different one that supports c++11.")
-endif()
-endif()
+    if (COMPILER_SUPPORTS_CXX17)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+    elseif (COMPILER_SUPPORTS_CXX11)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    else ()
+        message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no c++11 support. Please use a different one that supports c++11.")
+    endif ()
+endif ()
 # copy res dir
 
 file(COPY res DESTINATION .)
 
 # source files
+target_sources(LaTeX PRIVATE
+        # atom folder
+        src/atom/atom_basic.cpp
+        src/atom/atom_impl.cpp
+        src/atom/box.cpp
+        src/atom/colors_def.cpp
+        # core folder
+        src/core/core.cpp
+        src/core/formula.cpp
+        src/core/formula_def.cpp
+        src/core/localized_num.cpp
+        src/core/macro.cpp
+        src/core/macro_def.cpp
+        src/core/macro_impl.cpp
+        src/core/parser.cpp
+        # fonts folder
+        src/fonts/alphabet.cpp
+        src/fonts/font_basic.cpp
+        src/fonts/font_info.cpp
+        src/fonts/fonts.cpp
+        # res folder
+        src/res/builtin/formula_mappings.res.cpp
+        src/res/builtin/glue.res.cpp
+        src/res/builtin/symbol_mapping.res.cpp
+        src/res/builtin/tex_param.res.cpp
+        src/res/builtin/tex_symbols.res.cpp
+        src/res/font/bi10.def.cpp
+        src/res/font/bx10.def.cpp
+        src/res/font/cmbsy10.def.cpp
+        src/res/font/cmbx10.def.cpp
+        src/res/font/cmbxti10.def.cpp
+        src/res/font/cmex10.def.cpp
+        src/res/font/cmmi10.def.cpp
+        src/res/font/cmmi10_unchanged.def.cpp
+        src/res/font/cmmib10.def.cpp
+        src/res/font/cmmib10_unchanged.def.cpp
+        src/res/font/cmr10.def.cpp
+        src/res/font/cmss10.def.cpp
+        src/res/font/cmssbx10.def.cpp
+        src/res/font/cmssi10.def.cpp
+        src/res/font/cmsy10.def.cpp
+        src/res/font/cmti10.def.cpp
+        src/res/font/cmti10_unchanged.def.cpp
+        src/res/font/cmtt10.def.cpp
+        src/res/font/dsrom10.def.cpp
+        src/res/font/eufb10.def.cpp
+        src/res/font/eufm10.def.cpp
+        src/res/font/i10.def.cpp
+        src/res/font/moustache.def.cpp
+        src/res/font/msam10.def.cpp
+        src/res/font/msbm10.def.cpp
+        src/res/font/r10.def.cpp
+        src/res/font/r10_unchanged.def.cpp
+        src/res/font/rsfs10.def.cpp
+        src/res/font/sb10.def.cpp
+        src/res/font/sbi10.def.cpp
+        src/res/font/si10.def.cpp
+        src/res/font/special.def.cpp
+        src/res/font/ss10.def.cpp
+        src/res/font/stmary10.def.cpp
+        src/res/font/tt10.def.cpp
+        src/res/parser/font_parser.cpp
+        src/res/parser/formula_parser.cpp
+        src/res/reg/builtin_font_reg.cpp
+        src/res/reg/builtin_syms_reg.cpp
+        src/res/sym/amsfonts.def.cpp
+        src/res/sym/amssymb.def.cpp
+        src/res/sym/base.def.cpp
+        src/res/sym/stmaryrd.def.cpp
+        src/res/sym/symspecial.def.cpp
+        # xml folder
+        src/xml/tinyxml2.cpp
 
-file(GLOB_RECURSE SRC "src/*.cpp")
+        src/latex.cpp
+        src/render.cpp
+        )
+target_include_directories(LaTeX PUBLIC src)
 
 # check operating system
 
-if(QT)
+if (QT)
     message(STATUS, "Cross platform build using Qt")
-    add_compile_definitions(BUILD_QT)
-    include_directories("src")
-    set(CMAKE_AUTOMOC ON)
-    find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets Quick REQUIRED)
-    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets Quick REQUIRED)
-    set(LINK_LIBS Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Quick)
-elseif(SKIA)
+    target_compile_definitions(LaTeX PUBLIC -DBUILD_QT)
+    find_package(QT NAMES Qt6 Qt5 COMPONENTS Gui Widgets REQUIRED)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Gui Widgets REQUIRED)
+    target_sources(LaTeX PRIVATE
+            src/platform/qt/graphic_qt.cpp
+    )
+    target_link_libraries(LaTeX PRIVATE
+            Qt${QT_VERSION_MAJOR}::Gui
+            )
+    add_executable(LaTeXQtSample
+            src/samples/qt_texwidget.cpp
+            src/samples/qt_mainwindow.cpp
+            src/samples/qt_main.cpp
+            )
+    target_link_libraries(LaTeXQtSample PRIVATE
+            Qt${QT_VERSION_MAJOR}::Widgets LaTeX)
+    set_target_properties(LaTeXQtSample PROPERTIES OUTPUT_NAME LaTeX)
+    set_target_properties(LaTeXQtSample PROPERTIES AUTOMOC ON)
+elseif (SKIA)
     message(STATUS, "Cross platform build using Qt and Skia for rendering")
-    add_compile_definitions(BUILD_SKIA)
-    add_compile_definitions(SK_GL)
-    include_directories(src ../skia ../skia/include)
-    link_directories(../skia)
-    set(CMAKE_AUTOMOC ON)
-    find_package(Qt5 COMPONENTS Widgets REQUIRED)
-    set(LINK_LIBS Qt5::Widgets skia)
-elseif(WIN32)
+    target_compile_definitions(LaTeX PUBLIC -DBUILD_SKIA -DSK_GL)
+    target_include_directories(LaTeX PUBLIC src)
+    if (MSVC)
+        find_package(skia REQUIRED)
+        target_link_libraries(LaTeX INTERFACE skia skia::skia)
+    else()
+        include_directories(../skia ../skia/include)
+        link_directories(../skia)
+    endif ()
+    find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Widgets REQUIRED)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Widgets REQUIRED)
+    target_sources(LaTeX PRIVATE
+            src/platform/skia/graphic_skia.cpp
+    )
+    target_link_libraries(LaTeX PRIVATE
+            Qt${QT_VERSION_MAJOR}::Core
+            )
+    add_executable(LaTeXQtSkiaSample
+            src/samples/qt_skiatexwidget.cpp
+            src/samples/qt_mainwindow.cpp
+            src/samples/qt_main.cpp
+    )
+    target_link_libraries(LaTeXQtSkiaSample PRIVATE
+            Qt${QT_VERSION_MAJOR}::Widgets LaTeX)
+    set_target_properties(LaTeXQtSkiaSample PROPERTIES OUTPUT_NAME LaTeX)
+    set_target_properties(LaTeXQtSkiaSample PROPERTIES AUTOMOC ON)
+elseif (WIN32)
     message(STATUS "We are working on Windows")
-    add_compile_definitions(BUILD_WIN32)
-    include_directories("src")
-    set(LINK_LIBS gdiplus)
-elseif(UNIX)
+    target_compile_definitions(LaTeX PUBLIC -DBUILD_WIN32 -D_HAS_STD_BYTE=0)
+    add_executable(LaTeXWin32Sample
+            src/platform/gdi_win/graphic_win32.cpp
+            src/samples/win32_main.cpp
+            )
+    target_link_libraries(LaTeXWin32Sample PRIVATE gdiplus LaTeX)
+    set_target_properties(LaTeXWin32Sample PROPERTIES OUTPUT_NAME LaTeX)
+elseif (UNIX)
     message(STATUS "We are working with GTK on a Unix like OS")
-    add_compile_definitions(BUILD_GTK)
-    find_package(PkgConfig)
+    target_compile_definitions(LaTeX PUBLIC -DBUILD_GTK)
+    find_package(PkgConfig REQUIRED)
     find_package(Fontconfig REQUIRED)
-    # include gtkmm module
-    pkg_check_modules(GTKMM gtkmm-3.0)
-    # include gtksourceview
-    pkg_check_modules(GSVMM gtksourceviewmm-3.0)
-    # includes and libraries
-    link_directories(${GTKMM_LIBRARY_DIRS} ${GSVMM_LIBRARY_DIRS} ${Fontconfig_LIBRARY_DIRS})
-    include_directories(${GTKMM_INCLUDE_DIRS} ${GSVMM_INCLUDE_DIRS} ${Fontconfig_INCLUDE_DIRS} "src")
-    set(LINK_LIBS ${GTKMM_LIBRARIES} ${GSVMM_LIBRARIES} ${Fontconfig_LIBRARIES})
-else()
+    pkg_check_modules(GTKMM REQUIRED IMPORTED_TARGET gtkmm-3.0)
+    pkg_check_modules(GSVMM REQUIRED IMPORTED_TARGET gtksourceviewmm-3.0)
+    pkg_check_modules(CairoMM REQUIRED IMPORTED_TARGET cairomm-1.0)
+    target_sources(LaTeX PRIVATE
+            src/platform/cairo/graphic_cairo.cpp
+    )
+    target_link_libraries(LaTeX PRIVATE
+            PkgConfig::GTKMM #include <pangomm/fontdescription.h>
+            PkgConfig::CairoMM #include <cairomm/context.h>
+            Fontconfig::Fontconfig
+            )
+    add_executable(LaTeXGtkSample
+            src/samples/gtkmm_main.cpp
+            )
+    target_link_libraries(LaTeXGtkSample PRIVATE
+            PkgConfig::GSVMM
+            LaTeX
+            )
+    set_target_properties(LaTeXGtkSample PROPERTIES OUTPUT_NAME LaTeX)
+else ()
     message(STATUS "We are working on a unknown platform")
     # other platforms...
-endif()
+endif ()
 
 # compile options
 
 option(HAVE_LOG "If enable log" ON)
-if(HAVE_LOG)
+if (HAVE_LOG)
     add_definitions(-DHAVE_LOG)
-endif()
+endif ()
 
 option(GRAPHICS_DEBUG "If enable graphics debug" ON)
-if(GRAPHICS_DEBUG)
+if (GRAPHICS_DEBUG)
     add_definitions(-DGRAPHICS_DEBUG)
-endif()
+endif ()
 
 option(MEM_CHECK "If compile for memory check only" OFF)
-if(MEM_CHECK)
+if (MEM_CHECK)
     add_definitions(-DMEM_CHECK)
-endif()
+endif ()
 
 option(QT "Compile using Qt instead of Win32/Gtk" OFF)
 
-add_executable(LaTeX ${SRC})
-target_link_libraries(LaTeX PUBLIC ${LINK_LIBS} ${CXX_FILESYSTEM_LIBRARIES})


### PR DESCRIPTION
Details:
1. separate library and executable files.
2. different platforms have different executable files.
3. rename all binary file to LaTeX.

Test Environment:
- for QT, Windows 10 Pro 20H2 Qt 6.0.0 msvc2019_64
- for UNIX(gtk), wsl ubuntu 20.04 gcc 9.3.0

Known issues:
- for WIN32, there are some bugs when build with MSVC.
I will fix them later.

- for SKIA, skia::skia target can't be imported normally.
The skia here is installed by `vcpkg.exe`.

```shell
vcpkg.exe install skia:x64-windows
```