### PR TITLE
Add Example: latex2png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ src/Doxyfile
 .vscode/
 prebuilt-scripts/
 .idea
-cmake-build-debug
+cmake-build-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,3 +228,9 @@ endif ()
 
 option(QT "Compile using Qt instead of Win32/Gtk" OFF)
 
+
+option(BUILD_EXAMPLE "Build examples" OFF)
+if (BUILD_EXAMPLE)
+    add_subdirectory(example)
+endif()
+

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(latex2png latex2png.cpp)
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui REQUIRED)
+target_link_libraries(latex2png PRIVATE
+        LaTeX
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Gui
+        )

--- a/example/latex2png.cpp
+++ b/example/latex2png.cpp
@@ -1,0 +1,76 @@
+//
+// Created by pikachu on 2021/5/11.
+//
+
+
+#include "latex.h"
+#include "platform/qt/graphic_qt.h"
+#include <QGuiApplication>
+#include <QFile>
+#include <QCommandLineParser>
+#include <QDebug>
+#include <QPainter>
+#include <QPixmap>
+#include <QTimer>
+
+class TexGuard {
+public:
+    TexGuard() {
+        tex::LaTeX::init();
+    }
+
+    ~TexGuard() {
+        tex::LaTeX::release();
+    }
+};
+
+int main(int argc, char **argv) {
+    QGuiApplication app(argc, argv);
+    TexGuard texGuard;
+#ifdef BUILD_SKIA
+    initGL();
+#endif
+    if (argc != 3) {
+        qDebug() << "Usage: latex2png tex_name png_name";
+        return 1;
+    }
+    for (int i = 0; i < argc; i++) {
+        qDebug() << i << argv[i];
+    }
+    QString texName = argv[1];
+    QString pngName = argv[2];
+    if (!pngName.endsWith(".png")) {
+        pngName += ".png";
+    }
+    QFile file(texName);
+    if (!file.exists()) {
+        qDebug() << "file not exist." << texName;
+        return 2;
+    }
+    auto ok = file.open(QIODevice::ReadOnly);
+    if (!ok) {
+        qDebug() << "file open fail." << texName;
+        return 3;
+    }
+    QString latex = file.readAll();
+    qDebug() << latex;
+    auto render = tex::LaTeX::parse(
+            latex.toStdWString(),
+            600 - 0 * 2,
+            20,
+            20 / 3.f,
+            0xff424242);
+    qDebug() << render->getWidth() << render->getHeight();
+    QPixmap img(render->getWidth(), render->getHeight());
+    img.fill(Qt::white);
+    QPainter painter(&img);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    tex::Graphics2D_qt g2(&painter);
+    render->draw(g2, 0, 0);
+    ok = img.save(pngName);
+    if (!ok) {
+        qDebug() << "save image fail." << pngName;
+        return 4;
+    }
+    return 0;
+}


### PR DESCRIPTION
I write a simple demo to show how to use this library.
The example (latex2png) converts a latex snippet into a picture(.png) with Qt.

```
Usage: latex2png tex_name png_name
```