### PR TITLE
fix error LNK2001: unresolved external symbol

### DIFF
--- a/src/atom/atom_char.cpp
+++ b/src/atom/atom_char.cpp
@@ -5,9 +5,9 @@
 using namespace tex;
 using namespace std;
 
-sptr<CharFont> FixedCharAtom::getCharFont(TeXFont& tf) {
-  return _cf;
-}
+//sptr<CharFont> FixedCharAtom::getCharFont(TeXFont& tf) {
+//  return _cf;
+//}
 
 sptr<Box> FixedCharAtom::createBox(Environment& env) {
   const auto& i = env.getTeXFont();
@@ -51,9 +51,9 @@ sptr<Box> SymbolAtom::createBox(Environment& env) {
   return cb;
 }
 
-sptr<CharFont> SymbolAtom::getCharFont(TeXFont& tf) {
-  return tf.getChar(_name, TexStyle::display).getCharFont();
-}
+//sptr<CharFont> SymbolAtom::getCharFont(TeXFont& tf) {
+//  return tf.getChar(_name, TexStyle::display).getCharFont();
+//}
 
 void SymbolAtom::addSymbolAtom(const string& file) {
   TeXSymbolParser parser(file);
@@ -79,9 +79,10 @@ Char CharAtom::getChar(TeXFont& tf, TexStyle style, bool smallCap) {
   return tf.getChar(chr, _textStyle, style);
 }
 
-sptr<CharFont> CharAtom::getCharFont(TeXFont& tf) {
-  return getChar(tf, TexStyle::display, false).getCharFont();
-}
+//sptr<CharFont> CharAtom::getCharFont(TeXFont& tf) {
+//    std::cout << "???" << std::endl;
+//  return getChar(tf, TexStyle::display, false).getCharFont();
+//}
 
 sptr<Box> CharAtom::createBox(Environment& env) {
   if (_textStyle.empty()) {

--- a/src/atom/atom_char.h
+++ b/src/atom/atom_char.h
@@ -4,7 +4,8 @@
 #include "common.h"
 #include "atom/atom.h"
 #include "box/box_group.h"
-
+#include "fonts/font_basic.h"
+#include "fonts/tex_font.h"
 namespace tex {
 
 struct CharFont;
@@ -67,7 +68,9 @@ public:
 
   explicit FixedCharAtom(const sptr<CharFont>& c) : _cf(c) {}
 
-  sptr<CharFont> getCharFont(TeXFont& tf) override;
+  sptr<CharFont> getCharFont(TeXFont& tf) override {
+      return _cf;
+  }
 
   sptr<Box> createBox(Environment& env) override;
 
@@ -112,7 +115,9 @@ public:
 
   sptr<Box> createBox(Environment& env) override;
 
-  sptr<CharFont> getCharFont(TeXFont& tf) override;
+  sptr<CharFont> getCharFont(TeXFont& tf) override {
+      return tf.getChar(_name, TexStyle::display).getCharFont();
+  }
 
   static void addSymbolAtom(const std::string& file);
 
@@ -176,7 +181,9 @@ public:
 
   sptr<Box> createBox(Environment& env) override;
 
-  sptr<CharFont> getCharFont(TeXFont& tf) override;
+  sptr<CharFont> getCharFont(TeXFont& tf) override {
+      return getChar(tf, TexStyle::display, false).getCharFont();
+  }
 
   __decl_clone(CharAtom)
 };

--- a/src/fonts/font_info.cpp
+++ b/src/fonts/font_info.cpp
@@ -23,17 +23,17 @@ const int* const FontInfo::getExtension(wchar_t ch) const {
   return _extensions.isEmpty() ? nullptr : _extensions((int)ch) + 1;
 }
 
-sptr<CharFont> FontInfo::getNextLarger(wchar_t ch) const {
-  const int* const item = _nextLargers((int)ch);
-  if (item == nullptr) return nullptr;
-  return sptrOf<CharFont>(item[1], item[2]);
-}
+//sptr<CharFont> FontInfo::getNextLarger(wchar_t ch) const {
+//  const int* const item = _nextLargers((int)ch);
+//  if (item == nullptr) return nullptr;
+//  return sptrOf<CharFont>(item[1], item[2]);
+//}
 
-sptr<CharFont> FontInfo::getLigture(wchar_t left, wchar_t right) const {
-  const wchar_t* const item = _lig(left, right);
-  if (item == nullptr) return nullptr;
-  return sptrOf<CharFont>(item[2], _id);
-}
+//sptr<CharFont> FontInfo::getLigture(wchar_t left, wchar_t right) const {
+//  const wchar_t* const item = _lig(left, right);
+//  if (item == nullptr) return nullptr;
+//  return sptrOf<CharFont>(item[2], _id);
+//}
 
 float FontInfo::getKern(wchar_t left, wchar_t right, float factor) const {
   const float* const item = _kern((float)left, (float)right);

--- a/src/fonts/font_info.h
+++ b/src/fonts/font_info.h
@@ -121,9 +121,17 @@ public:
 
   const int* const getExtension(wchar_t ch) const;
 
-  sptr<CharFont> getNextLarger(wchar_t ch) const;
+  sptr<CharFont> getNextLarger(wchar_t ch) const {
+      const int* const item = _nextLargers((int)ch);
+      if (item == nullptr) return nullptr;
+      return sptrOf<CharFont>(item[1], item[2]);
+  }
 
-  sptr<CharFont> getLigture(wchar_t left, wchar_t right) const;
+  sptr<CharFont> getLigture(wchar_t left, wchar_t right) const {
+      const wchar_t* const item = _lig(left, right);
+      if (item == nullptr) return nullptr;
+      return sptrOf<CharFont>(item[2], _id);
+  }
 
   float getKern(wchar_t left, wchar_t right, float factor) const;
 


### PR DESCRIPTION
This a dirty PR to fix https://github.com/NanoMichael/cLaTeXMath/pull/73#issuecomment-842803855

I am very confused that all functions are implemented in the cpp file, but MSVC still reports errors.
```
error LNK2001: unresolved external symbol
```

When I move the code to the header(.h) file, the problem disappeared.

Maybe I can find better way to solve this bug later.