### PR TITLE
fix: build dll in win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ if (MSVC)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     add_compile_options("/utf-8")
     target_compile_features(clatexmath PUBLIC cxx_std_17)
+    target_compile_definitions(clatexmath PRIVATE -DCLATEXMATH_LIBRARY)
 else ()
 
     # check if compiler has c++17 support
@@ -172,12 +173,19 @@ elseif (SKIA)
 elseif (WIN32)
     message(STATUS "We are working on Windows")
     target_compile_definitions(clatexmath PUBLIC -DBUILD_WIN32 -D_HAS_STD_BYTE=0)
+    target_sources(
+        clatexmath PRIVATE
+        src/platform/gdi_win/graphic_win32.cpp
+    )
+    target_link_libraries(
+        clatexmath PUBLIC
+        gdiplus
+    )
     add_executable(
         LaTeXWin32Sample WIN32
-        src/platform/gdi_win/graphic_win32.cpp
         src/samples/win32_main.cpp
     )
-    target_link_libraries(LaTeXWin32Sample PRIVATE gdiplus clatexmath)
+    target_link_libraries(LaTeXWin32Sample PRIVATE clatexmath)
     set_target_properties(LaTeXWin32Sample PROPERTIES OUTPUT_NAME LaTeX)
 elseif (UNIX)
     message(STATUS "We are working with GTK on a Unix like OS")

--- a/src/config.h
+++ b/src/config.h
@@ -48,5 +48,13 @@
 #else
 #define CLATEX_CXX17 0
 #endif
-
+#ifdef _MSC_VER
+#if defined(CLATEXMATH_LIBRARY)
+#define CLATEXMATH_EXPORT __declspec(dllexport)
+#else
+#define CLATEXMATH_EXPORT __declspec(dllimport)
+#endif
+#else
+#define CLATEXMATH_EXPORT
+#endif
 #endif  // LATEX_CONFIG_H

--- a/src/latex.h
+++ b/src/latex.h
@@ -3,12 +3,13 @@
 
 #include <string>
 
+#include "config.h"
 #include "unimath/uni_font.h"
 #include "render.h"
 
 namespace tex {
 
-class LaTeX {
+class CLATEXMATH_EXPORT LaTeX {
 private:
   static volatile bool _isInited;
   static std::string _defaultMathFontName;

--- a/src/platform/gdi_win/graphic_win32.h
+++ b/src/platform/gdi_win/graphic_win32.h
@@ -78,7 +78,7 @@ public:
 
 /**************************************************************************************************/
 
-class Graphics2D_win32 : public Graphics2D {
+class CLATEXMATH_EXPORT Graphics2D_win32 : public Graphics2D {
 private:
   static const Gdiplus::StringFormat* _format;
 

--- a/src/platform/qt/graphic_qt.h
+++ b/src/platform/qt/graphic_qt.h
@@ -52,7 +52,7 @@ public:
 
 /**************************************************************************************************/
 
-class Graphics2D_qt : public Graphics2D {
+class CLATEXMATH_EXPORT Graphics2D_qt : public Graphics2D {
 private:
   QPainter* _painter;
 

--- a/src/render.h
+++ b/src/render.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 
+#include "config.h"
 #include "utils/enums.h"
 #include "box/box.h"
 #include "graphic/graphic.h"
@@ -24,7 +25,7 @@ using BoxFilter = std::function<bool(const sptr<Box>&)>;
  * You can change the size via method #setWidth and #setHeight, but only the new
  * size is larger will be handled.
  */
-class Render {
+class CLATEXMATH_EXPORT Render {
 private:
   static constexpr color DFT_COLOR = black;
 


### PR DESCRIPTION
In win, we use `__declspec(dllexport)` to export symbols when building dll
and use `__declspec(dllimport)` to import symbols from dll.