### PR TITLE
improved meson files & fixed qt-build and example

### DIFF
--- a/example/gtk/meson.build
+++ b/example/gtk/meson.build
@@ -2,13 +2,12 @@ example_gtk_src = [
     'gtkmm_main.cpp',
     '../samples/samples.cpp'
 ]
-example_gtk_inc = inc
-example_gtk_inc += '../samples'
-example_gtk_inc += cairo_inc
+example_gtk_inc = '../samples'
 
 example_gtk_deps = [
     dependency('gtkmm-3.0'),
-    dependency('gtksourceviewmm-3.0')
+    dependency('gtksourceviewmm-3.0'),
+    clatexmath_cairo_dep
 ]
 
 executable(

--- a/example/qt/qt_mainwindow.cpp
+++ b/example/qt/qt_mainwindow.cpp
@@ -7,7 +7,7 @@
 #include <QString>
 
 #include "qt_mainwindow.h"
-#include "moc_qt_mainwindow.cpp"
+//#include "moc_qt_mainwindow.cpp"
 
 using namespace std;
 

--- a/example/qt/qt_texqmlitem.cpp
+++ b/example/qt/qt_texqmlitem.cpp
@@ -41,7 +41,7 @@ void TexQmlItem::setLatexString(const QString& latex)
 
     try {
         _render = LaTeX::parse(
-            latex.toStdWString(),
+            latex.toStdString(),
             width() - _padding * 2,
             _text_size,
             _text_size / 3.f,

--- a/example/qt/qt_texqmlitem.h
+++ b/example/qt/qt_texqmlitem.h
@@ -22,7 +22,7 @@ public:
   QString latexString() const;
 
 private:
-  tex::TeXRender* _render;
+  tex::Render* _render;
   float _text_size;
   int _padding;
   QString m_latexString;

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -46,9 +46,14 @@ clatexmath_lib = library('clatexmath', src,
 	install: true
 )
 
+clatexmath_dep = declare_dependency(
+	link_with: clatexmath_lib,
+	include_directories: inc,
+	version: meson.project_version()
+)
+
 if get_option('TARGET_DEVEL')
-    import('pkgconfig').generate(
-        libraries: clatexmath_lib,
+    pkgconfig.generate(clatexmath_lib,
         version: meson.project_version(),
         name: 'clatexmath',
         filebase: 'clatexmath',

--- a/meson.build
+++ b/meson.build
@@ -3,20 +3,34 @@ project('clatexmath', 'cpp',
 	default_options : ['buildtype=release', 'warning_level=0', 'cpp_std=c++17']
 )
 
+if get_option('TARGET_DEVEL')
+  pkgconfig = import('pkgconfig')
+endif
+
 subdir('lib')
 
 if get_option('CAIRO')
-    subdir('platform/cairo')
+  subdir('platform/cairo')
+  if get_option('EXAMPLE_GTK')
+    subdir('example/gtk')
+  endif
+else
+  if get_option('EXAMPLE_GTK')
+    error('EXAMPLE_GTK was enabled, but it requires CAIRO platform')
+  endif
 endif
 
 if get_option('QT')
-    subdir('platform/qt')
+  subdir('platform/qt')
+  if get_option('EXAMPLE_QT')
+    subdir('example/qt')
+  endif
+else
+  if get_option('EXAMPLE_QT')
+    error('EXAMPLE_QT was enabled, but it requires QT platform')
+  endif
 endif
 
 if get_option('TEST')
     subdir('test')
-endif
-
-if get_option('EXAMPLE_GTK')
-    subdir('example/gtk')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,9 +6,10 @@ option('TEST', type: 'boolean', value: true)
 
 # if build cairo
 option('CAIRO', type: 'boolean', value: true)
+# if build gtk example
+option('EXAMPLE_GTK', type: 'boolean', value: true)
 
 # if build qt
 option('QT', type: 'boolean', value: true)
-
-# if build gtk example
-option('EXAMPLE_GTK', type: 'boolean', value: true)
+# if build qt example
+option('EXAMPLE_QT', type: 'boolean', value: true)

--- a/platform/cairo/meson.build
+++ b/platform/cairo/meson.build
@@ -4,10 +4,9 @@ cairo_src = [
 
 cairo_deps = [
     dependency('fontconfig'),
-    dependency('gdkmm-3.0')
+    dependency('cairomm-1.0'),
+    dependency('pangomm-1.4')
 ]
-
-cairo_inc = include_directories('.')
 
 clatexmath_cairo_lib = library('clatexmath-cairo', cairo_src,
     link_with: clatexmath_lib,
@@ -17,6 +16,23 @@ clatexmath_cairo_lib = library('clatexmath-cairo', cairo_src,
     soversion: 0,
     install: true
 )
+
+clatexmath_cairo_dep = declare_dependency(
+	link_with: [clatexmath_lib, clatexmath_cairo_lib],
+	include_directories: ['.', inc],
+	version: meson.project_version()
+)
+
+if get_option('TARGET_DEVEL')
+    pkgconfig.generate(clatexmath_cairo_lib,
+        libraries: clatexmath_lib,
+        version: meson.project_version(),
+        name: 'clatexmath-cairo',
+        filebase: 'clatexmath-cairo',
+        subdirs: ['clatexmath/platform/cairo'],
+        description: 'cairomm backend to cLaTeXMath'
+    )
+endif
 
 if install_headerfiles
     install_headers([

--- a/platform/qt/graphic_qt.h
+++ b/platform/qt/graphic_qt.h
@@ -10,6 +10,7 @@
 #include <QFont>
 #include <QMap>
 #include <QPainter>
+#include <QPainterPath>
 #include <QString>
 #include <QTextLayout>
 

--- a/platform/qt/meson.build
+++ b/platform/qt/meson.build
@@ -1,6 +1,9 @@
 qt5 = import('qt5')
-qt_dep = dependency('qt5', modules: ['Core', 'Gui', 'Widgets'])
-qt_src = qt5.preprocess(moc_headers: 'graphic_qt.h', include_directories: inc, dependencies: qt_dep)
+qt_dep = dependency('qt5', modules: ['Gui'])
+qt_src = [
+  qt5.preprocess(moc_headers: 'graphic_qt.h', include_directories: inc, dependencies: qt_dep),
+  'graphic_qt.cpp'
+]
 
 clatexmath_qt_lib = library('clatexmath-qt', qt_src,
     link_with: clatexmath_lib,
@@ -10,6 +13,23 @@ clatexmath_qt_lib = library('clatexmath-qt', qt_src,
     soversion: 0,
     install: true
 )
+
+clatexmath_qt_dep = declare_dependency(
+	link_with: [clatexmath_lib, clatexmath_qt_lib],
+	include_directories: ['.', inc],
+	version: meson.project_version()
+)
+
+if get_option('TARGET_DEVEL')
+    pkgconfig.generate(clatexmath_qt_lib,
+        libraries: clatexmath_lib,
+        version: meson.project_version(),
+        name: 'clatexmath-qt',
+        filebase: 'clatexmath-qt',
+        subdirs: ['clatexmath/platform/qt'],
+        description: 'qt5 backend to cLaTeXMath'
+    )
+endif
 
 if install_headerfiles
     install_headers([


### PR DESCRIPTION
I've noticed some issues with your latest changes to the buildfiles.

this should fix them :D

also btw, your changes introduced by 10a0e258c3433ab7d3d2fca6de7b0a694d89ddee have broken the otf2clm script, since it expects --batch or --single as first arg, but passes the first arg (in non-batch mode) as the otf filepath to batch_parse and instead it ignores the third passed param.