### PR TITLE
meson GDI support + (missing qt exmaple)

### DIFF
--- a/example/qt/meson.build
+++ b/example/qt/meson.build
@@ -1,0 +1,25 @@
+example_qt_dep = [
+  dependency('qt5', modules: ['Core', 'Gui', 'Widgets']),
+  clatexmath_qt_dep
+]
+
+example_qt_inc = ['../samples', inc]
+example_qt_src = [
+  qt5.preprocess(moc_headers: [
+      'qt_mainwindow.h',
+    ],
+    include_directories: example_qt_inc,
+    dependencies: example_qt_dep
+  ),
+  'qt_main.cpp',
+  'qt_mainwindow.cpp',
+  'qt_texwidget.cpp',
+  '../samples/samples.cpp'
+]
+
+executable(
+    'LaTeXQtExample', example_qt_src,
+    include_directories: example_qt_inc,
+    dependencies: example_qt_dep,
+    install: true
+)

--- a/example/win32/meson.build
+++ b/example/win32/meson.build
@@ -1,0 +1,18 @@
+example_gdi_src = [
+    'win32_main.cpp',
+    '../samples/samples.cpp'
+]
+example_gdi_inc = '../samples'
+
+example_gdi_deps = [
+    gdi_dep,
+    clatexmath_gdi_dep
+]
+
+executable(
+    'LaTeXGdiExample', example_gdi_src,
+    include_directories: example_gdi_inc,
+    link_with: [clatexmath_gdi_lib, clatexmath_lib],
+    dependencies: example_gdi_deps,
+    install: true
+)

--- a/example/win32/win32_main.cpp
+++ b/example/win32/win32_main.cpp
@@ -1,9 +1,7 @@
 #include "config.h"
 
-#if defined(BUILD_WIN32) && !defined(MEM_CHECK)
-
 #include "latex.h"
-#include "platform/gdi_win/graphic_win32.h"
+#include "graphic_win32.h"
 #include "samples.h"
 #include "utils/string_utils.h"
 
@@ -135,12 +133,14 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) 
 
 void init() {
   // TODO
-  const FontSpec math{
-    "xits",
-    "C:\\Users\\artia\\Downloads\\xits\\xits\\XITSMath-Regular.otf",
-    "./res/XITSMath-Regular.clm"
+  const FontSrcFile math{
+    "Latin Modern Math",
+    "./res/lm-math.clm",
+    "Z:\\usr\\share\\fonts\\texlive-lm-math\\latinmodern-math.otf"
   };
   LaTeX::init(math);
+  PlatformFactory::registerFactory("gdi", std::make_unique<PlatformFactory_gdi>());
+  PlatformFactory::activate("gdi");
   _samples = new Samples("./res/SAMPLES.tex");
   _render = LaTeX::parse(
     "\\text{What a beautiful day! Press Ctrl + Enter to show formulas.}",
@@ -355,5 +355,3 @@ LRESULT CALLBACK CanvasProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
   }
   return 0;
 }
-
-#endif

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,8 @@ project('clatexmath', 'cpp',
 	default_options : ['buildtype=release', 'warning_level=0', 'cpp_std=c++17']
 )
 
+cpp = meson.get_compiler('cpp')
+
 if get_option('TARGET_DEVEL')
   pkgconfig = import('pkgconfig')
 endif
@@ -28,6 +30,18 @@ if get_option('QT')
 else
   if get_option('EXAMPLE_QT')
     error('EXAMPLE_QT was enabled, but it requires QT platform')
+  endif
+endif
+
+gdi_dep = cpp.find_library('gdiplus', required: get_option('GDI'))
+if gdi_dep.found() and cpp.has_header('windows.h')
+  subdir('platform/gdi_win')
+  if get_option('EXAMPLE_WIN32')
+    subdir('example/win32')
+  endif
+else
+  if get_option('EXAMPLE_WIN32')
+    error('EXAMPLE_WIN32 was enabled, but it requires GDI platform')
   endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,3 +13,8 @@ option('EXAMPLE_GTK', type: 'boolean', value: true)
 option('QT', type: 'boolean', value: true)
 # if build qt example
 option('EXAMPLE_QT', type: 'boolean', value: true)
+
+# if build gdi
+option('GDI', type: 'feature')
+# if build win32 example
+option('EXAMPLE_WIN32', type: 'boolean', value: false)

--- a/platform/gdi_win/graphic_win32.cpp
+++ b/platform/gdi_win/graphic_win32.cpp
@@ -1,8 +1,6 @@
 #include "config.h"
 
-#if defined(BUILD_WIN32) && !defined(MEM_CHECK)
-
-#include "platform/gdi_win/graphic_win32.h"
+#include "graphic_win32.h"
 #include "utils/nums.h"
 #include "utils/exceptions.h"
 
@@ -86,10 +84,6 @@ Font_win32::~Font_win32() noexcept {
   if (!_isSystem) delete _family;
 }
 
-sptr<tex::Font> tex::Font::create(const std::string& file) {
-  return Font_win32::getOrCreate(file);
-}
-
 /**************************************************************************************************/
 
 Gdiplus::Graphics* TextLayout_win32::_g = nullptr;
@@ -151,7 +145,13 @@ void TextLayout_win32::draw(Graphics2D& g2, float x, float y) {
   g.setFont(prev);
 }
 
-sptr<TextLayout> TextLayout::create(const std::string& src, FontStyle style, float size) {
+/**************************************************************************************************/
+
+sptr<tex::Font> PlatformFactory_gdi::createFont(const std::string& file) {
+  return Font_win32::getOrCreate(file);
+}
+
+sptr<TextLayout> PlatformFactory_gdi::createTextLayout(const std::string& src, FontStyle style, float size) {
   return sptrOf<TextLayout_win32>(src, style, size);
 }
 
@@ -295,6 +295,34 @@ void Graphics2D_win32::drawGlyph(u16 glyph, float x, float y) {
   _g->DrawDriverString(&glyph, 1, f.get(), _brush, &p, 0, nullptr);
 }
 
+void Graphics2D_win32::beginPath() {
+  // not supported
+}
+
+void Graphics2D_win32::moveTo(float x, float y) {
+  // not supported
+}
+
+void Graphics2D_win32::lineTo(float x, float y) {
+  // not supported
+}
+
+void Graphics2D_win32::cubicTo(float x1, float y1, float x2, float y2, float x3, float y3) {
+  // not supported
+}
+
+void Graphics2D_win32::quadTo(float x1, float y1, float x2, float y2) {
+  // not supported
+}
+
+void Graphics2D_win32::closePath() {
+  // not supported
+}
+
+void Graphics2D_win32::fillPath() {
+  // not supported
+}
+
 void Graphics2D_win32::drawText(const std::wstring& src, float x, float y) {
   auto f = std::static_pointer_cast<Font_win32>(_font);
   int em = f->getEmHeight();
@@ -330,5 +358,3 @@ void Graphics2D_win32::fillRoundRect(float x, float y, float w, float h, float r
   // not supported
   fillRect(x, y, w, h);
 }
-
-#endif

--- a/platform/gdi_win/graphic_win32.h
+++ b/platform/gdi_win/graphic_win32.h
@@ -1,7 +1,5 @@
 #include "config.h"
 
-#if defined(BUILD_WIN32) && !defined(MEM_CHECK)
-
 #ifndef GRAPHIC_WIN32_H_INCLUDED
 #define GRAPHIC_WIN32_H_INCLUDED
 
@@ -78,6 +76,15 @@ public:
 
 /**************************************************************************************************/
 
+class PlatformFactory_gdi : public PlatformFactory {
+public:
+  sptr<Font> createFont(const std::string &file) override;
+
+  sptr<TextLayout> createTextLayout(const std::string &src, FontStyle style, float size) override;
+};
+
+/**************************************************************************************************/
+
 class CLATEXMATH_EXPORT Graphics2D_win32 : public Graphics2D {
 private:
   static const Gdiplus::StringFormat* _format;
@@ -135,6 +142,20 @@ public:
 
   void drawGlyph(u16 glyph, float x, float y) override;
 
+  void beginPath() override;
+
+  void moveTo(float x, float y) override;
+
+  void lineTo(float x, float y) override;
+
+  void cubicTo(float x1, float y1, float x2, float y2, float x3, float y3) override;
+
+  void quadTo(float x1, float y1, float x2, float y2) override;
+
+  void closePath() override;
+
+  void fillPath() override;
+
   /** Draw text */
   void drawText(const std::wstring& src, float x, float y);
 
@@ -152,4 +173,3 @@ public:
 }  // namespace tex
 
 #endif  // GRAPHIC_WIN32_H_INCLUDED
-#endif

--- a/platform/gdi_win/meson.build
+++ b/platform/gdi_win/meson.build
@@ -1,0 +1,39 @@
+gdi_src = [
+    'graphic_win32.cpp'
+]
+
+gdi_deps = [
+    gdi_dep
+]
+
+clatexmath_gdi_lib = library('clatexmath-gdi', gdi_src,
+    link_with: [clatexmath_lib],
+    include_directories: inc,
+    dependencies: gdi_deps,
+    version: meson.project_version(),
+    soversion: 0,
+    install: true
+)
+
+clatexmath_gdi_dep = declare_dependency(
+	link_with: [clatexmath_lib, clatexmath_gdi_lib],
+	include_directories: ['.', inc],
+	version: meson.project_version()
+)
+
+if get_option('TARGET_DEVEL')
+    pkgconfig.generate(clatexmath_gdi_lib,
+        libraries: clatexmath_lib,
+        version: meson.project_version(),
+        name: 'clatexmath-gdi',
+        filebase: 'clatexmath-gdi',
+        subdirs: ['clatexmath/platform/gdi_win'],
+        description: 'win32 backend to cLaTeXMath'
+    )
+endif
+
+if install_headerfiles
+    install_headers([
+        'graphic_win32.h'
+    ], subdir: 'clatexmath/platform/gdi_win')
+endif


### PR DESCRIPTION
now it is possible to build the gdi lib from meson too (but I've only tested with gcc & mingw, not microsoft's libs).

However gdi is not yet fully fixed yet. The new path methods of the Graphics2D class are not yet implemented, but I think one could implement it (https://docs.microsoft.com/en-us/windows/win32/gdiplus/-gdiplus-constructing-and-drawing-paths-use)

However at least on wine it still doesn't run, as it throws:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  locale::facet::_S_create_c_locale name not valid
```

one can work around this, by replacing `locale("en_US.UTF-8")` with `locale("C")` in `lib/utils/utils.cpp`, but then the window only pops up for a frame, after which it throws:
```
terminate called after throwing an instance of 'tex::ex_invalid_state'
  what():  Cannot load font file Z:\usr\share\fonts\texlive-lm-math\latinmodern-math.otf
```
the `c.AddFontFile(wfile.c_str())` in `graphic_win32.cpp` returns `3` as status, which (if I have understood correctly) implies [OutOfMemory](https://docs.microsoft.com/en-us/windows/win32/api/gdiplustypes/ne-gdiplustypes-status). And OutOfMemory gets returned, when mono/gdiplus fails to convert the filepath from utf16 to utf8: https://github.com/mono/libgdiplus/blob/94a49875487e296376f209fe64b921c6020f74c0/src/font.c#L234 , but I didn't investigate further.