### PR TITLE
WIP: Lookup fonts from filesystem

### DIFF
--- a/example/gtk/gtkmm_main.cpp
+++ b/example/gtk/gtkmm_main.cpp
@@ -521,7 +521,7 @@ int main(int argc, char* argv[]) {
 
   Pango::init();
   const FontSrcFile math{mathVersionName, clmFile, mathFont};
-  TinyTeX::init(math);
+  TinyTeX::init(&math);
 
   PlatformFactory::registerFactory("gtk", std::make_unique<PlatformFactory_cairo>());
   PlatformFactory::activate("gtk");

--- a/example/memcheck/mem_check_main.cpp
+++ b/example/memcheck/mem_check_main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   const tinytex::FontSrcFile math{argv[1], argv[2], argv[3]};
-  tinytex::TinyTeX::init(math);
+  tinytex::TinyTeX::init(&math);
 
   tinytex::PlatformFactory::registerFactory("none", std::make_unique<tinytex::PlatformFactory_none>());
   tinytex::PlatformFactory::activate("none");

--- a/example/qt/qt_main.cpp
+++ b/example/qt/qt_main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
     return 1;
   }
   const tinytex::FontSrcFile math{argv[1], argv[2], argv[3]};
-  tinytex::TinyTeX::init(math);
+  tinytex::TinyTeX::init(&math);
 
   tinytex::PlatformFactory::registerFactory("qt", std::make_unique<tinytex::PlatformFactory_qt>());
   tinytex::PlatformFactory::activate("qt");

--- a/example/qtpng/latex2png.cpp
+++ b/example/qtpng/latex2png.cpp
@@ -17,7 +17,7 @@
 class TexGuard {
 public:
   TexGuard(const tinytex::FontSrc& math) {
-    tinytex::TinyTeX::init(math);
+    tinytex::TinyTeX::init(&math);
     tinytex::PlatformFactory::registerFactory("qt", std::make_unique<tinytex::PlatformFactory_qt>());
     tinytex::PlatformFactory::activate("qt");
   }

--- a/example/win32/win32_main.cpp
+++ b/example/win32/win32_main.cpp
@@ -147,7 +147,7 @@ void init() {
     exit(1);
   }
   const FontSrcFile math{__argv[2], __argv[3], __argv[4]};
-  TinyTeX::init(math);
+  TinyTeX::init(&math);
   PlatformFactory::registerFactory("gdi", std::make_unique<PlatformFactory_gdi>());
   PlatformFactory::activate("gdi");
   _samples = new Samples(__argv[5]);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(
     utils/utils.cpp
     # otf folder
     otf/clm.cpp
+	otf/fontsense.cpp
     otf/glyph.cpp
     otf/otf.cpp
     otf/path.cpp

--- a/lib/config.h
+++ b/lib/config.h
@@ -7,7 +7,7 @@
 #endif
 
 // The clm data major version
-#define CLM_VER_MAJOR 2
+#define CLM_VER_MAJOR 3
 
 // The clm data minor version, must be 1 or 2
 #ifdef HAVE_GLYPH_RENDER_PATH

--- a/lib/otf/clm.cpp
+++ b/lib/otf/clm.cpp
@@ -119,6 +119,7 @@ public:
 
 void CLMReader::readMeta(Otf& font, BinaryReader& reader) {
   font._name = std::string(reader.read_string());
+  font._family = std::string(reader.read_string());
   font._isMathFont = reader.read<bool>();
   font._em = reader.read<u16>();
   font._xHeight = reader.read<u16>();

--- a/lib/otf/fontsense.cpp
+++ b/lib/otf/fontsense.cpp
@@ -14,146 +14,146 @@ namespace fs = std::filesystem;
 
 namespace tinytex {
 
-font_paths_t get_font_paths() {
-	std::queue<std::string> paths;
-	// checks if TINYTEX_FONTDIR exists. If it does, it pushes it to potential paths.
-	char* devdir = getenv("TINYTEX_FONTDIR");
-	if (devdir && *devdir)
-		paths.push(std::string(devdir));
+font_paths_t GetFontPaths() {
+  std::queue<std::string> paths;
+  // checks if TINYTEX_FONTDIR exists. If it does, it pushes it to potential paths.
+  char* devdir = getenv("TINYTEX_FONTDIR");
+  if (devdir && *devdir)
+    paths.push(std::string(devdir));
 
-	// checks if XDG_DATA_HOME exists. If it does, it pushes it to potential paths.
-	char* userdata = getenv("XDG_DATA_HOME");
-	if (userdata && *userdata)
-		paths.push(std::string(userdata) + "/" + FONTDIR);
+  // checks if XDG_DATA_HOME exists. If it does, it pushes it to potential paths.
+  char* userdata = getenv("XDG_DATA_HOME");
+  if (userdata && *userdata)
+    paths.push(std::string(userdata) + "/" + FONTDIR);
 
-	// checks if XDG_DATA_DIRS is set. If it is, it splits XDG_DATA_DIRS at : and
-	// pushes each part of it to potential paths.
-	char* data_dirs = getenv("XDG_DATA_DIRS");
-	if (data_dirs && *data_dirs) {
-		std::stringstream data_dir_paths(data_dirs);
-		std::string data_dir_path;
-		while(getline(data_dir_paths, data_dir_path, ':'))
-			paths.push(data_dir_path + "/" + FONTDIR);
-	}
+  // checks if XDG_DATA_DIRS is set. If it is, it splits XDG_DATA_DIRS at : and
+  // pushes each part of it to potential paths.
+  char* data_dirs = getenv("XDG_DATA_DIRS");
+  if (data_dirs && *data_dirs) {
+    std::stringstream data_dir_paths(data_dirs);
+    std::string data_dir_path;
+    while(getline(data_dir_paths, data_dir_path, ':'))
+      paths.push(data_dir_path + "/" + FONTDIR);
+  }
 
 #ifndef _WIN32
-	char* home = getenv("HOME");
-	if (home || *home) {
-		char* userdata_fallback;
-		asprintf(&userdata_fallback, "%s/.local/share/%s/", home, FONTDIR);
-		paths.push(std::string(userdata_fallback));
-		free(userdata_fallback);
-	}
+  char* home = getenv("HOME");
+  if (home || *home) {
+    char* userdata_fallback;
+    asprintf(&userdata_fallback, "%s/.local/share/%s/", home, FONTDIR);
+    paths.push(std::string(userdata_fallback));
+    free(userdata_fallback);
+  }
 
-	paths.push("/usr/local/share/" FONTDIR);
-	paths.push("/usr/share/" FONTDIR);
+  paths.push("/usr/local/share/" FONTDIR);
+  paths.push("/usr/share/" FONTDIR);
 #endif
 
-	font_paths_t font_paths;
+  font_paths_t font_paths;
 
-	/*
-	 * Iterate over all found data dirs. For each dir iterate over
-	 * all files in it. For each font there should be a stem.otf and
-	 * stem.clm file available. This function checks if the filestem
-	 * is already in the font map and if it is, looks at the current
-	 * file extention and sets the current path to it it if is unset.
-	 * If the stem is not currently in the map it adds it together
-	 * with the current file as clm or otf.
-	 */
-	while (!paths.empty()) {
-		fs::path p = paths.front();
-		if (fs::exists(p))
-			for (const auto& entry : fs::directory_iterator(p)) {
-				fs::path path = entry.path();
-				std::string stem = path.stem().string();
-				std::string ext = path.extension().string();
-				font_paths_t::iterator it = font_paths.find(stem);
-				if (it != font_paths.end()) {
-					if (ext == ".otf" && !it->second.first)
-						it->second.first = strdup(path.string().c_str());
-					if (ext == ".clm" && !it->second.second)
-						it->second.second = strdup(path.string().c_str());
+  /*
+   * Iterate over all found data dirs. For each dir iterate over
+   * all files in it. For each font there should be a stem.otf and
+   * stem.clm file available. This function checks if the filestem
+   * is already in the font map and if it is, looks at the current
+   * file extention and sets the current path to it it if is unset.
+   * If the stem is not currently in the map it adds it together
+   * with the current file as clm or otf.
+   */
+  while (!paths.empty()) {
+    fs::path p = paths.front();
+    if (fs::exists(p))
+      for (const auto& entry : fs::directory_iterator(p)) {
+        fs::path path = entry.path();
+        std::string stem = path.stem().string();
+        std::string ext = path.extension().string();
+        font_paths_t::iterator it = font_paths.find(stem);
+        if (it != font_paths.end()) {
+          if (ext == ".otf" && !it->second.first)
+            it->second.first = strdup(path.string().c_str());
+          if (ext == ".clm" && !it->second.second)
+            it->second.second = strdup(path.string().c_str());
 
-				} else {
-					font_paths.emplace(stem, std::pair(
-						ext == ".otf" ? strdup(path.string().c_str()) : NULL,
-						ext == ".clm" ? strdup(path.string().c_str()) : NULL
-					));
-				}
-			}
-		paths.pop();
-	}
+        } else {
+          font_paths.emplace(stem, std::pair(
+            ext == ".otf" ? strdup(path.string().c_str()) : NULL,
+            ext == ".clm" ? strdup(path.string().c_str()) : NULL
+          ));
+        }
+      }
+    paths.pop();
+  }
 
-	/*
-	 * Iterate over all font paths in map and remove all of them
-	 * where either the oth or clm path is NULL.
-	 */
-	for (font_paths_t::iterator it = font_paths.begin(); it != font_paths.end(); ) {
-		if (!it->second.first || !it->second.second)
-			font_paths.erase(it++);
-		else
-			it++;
-	}
+  /*
+   * Iterate over all font paths in map and remove all of them
+   * where either the oth or clm path is NULL.
+   */
+  for (font_paths_t::iterator it = font_paths.begin(); it != font_paths.end(); ) {
+    if (!it->second.first || !it->second.second)
+      font_paths.erase(it++);
+    else
+      it++;
+  }
 
-	return font_paths;
+  return font_paths;
 }
 
-void font_paths_free(font_paths_t font_paths) {
-	for (auto [_stem, files] : font_paths) {
-		free(files.first);
-		free(files.second);
-	}
+void FontPathsFree(font_paths_t font_paths) {
+  for (auto [_stem, files] : font_paths) {
+    free(files.first);
+    free(files.second);
+  }
 }
 
-std::optional<const std::string> fontsense_lookup() {
-	std::optional<std::string> mathfont;
+std::optional<const std::string> FontsenseLookup() {
+  std::optional<std::string> mathfont;
 
-	font_paths_t font_paths = get_font_paths();
+  font_paths_t font_paths = GetFontPaths();
 
-	font_families_t font_families;
+  font_families_t font_families;
 
-	for (const auto& [_stem, files] : font_paths) {
-		Otf* font = Otf::fromFile(files.second);
-		if (font->isMathFont()) {
-			FontContext::addMathFont(FontSrcSense(font, std::string(files.first)));
+  for (const auto& [_stem, files] : font_paths) {
+    Otf* font = Otf::fromFile(files.second);
+    if (font->isMathFont()) {
+      FontContext::addMathFont(FontSrcSense(font, std::string(files.first)));
 
-			if (!mathfont)
-				mathfont = font->name();
-		}
-		else {
-			font_families_t::iterator it = font_families.find(font->family());
-			if (it != font_families.end()) {
-				auto iit = it->second.find(font->name());
-				if (iit == it->second.end()) {
-					it->second.emplace(font->name(), FontSrcSense(font, std::string(files.first)));
-				}
-			} else {
-				std::map<std::string, FontSrcSense> family { {
-					font->name(),
-					FontSrcSense(font, std::string(files.first))
-				} };
-				font_families.emplace(font->family(), std::move(family));
-			}
-		}
-	}
+      if (!mathfont)
+        mathfont = font->name();
+    }
+    else {
+      font_families_t::iterator it = font_families.find(font->family());
+      if (it != font_families.end()) {
+        auto iit = it->second.find(font->name());
+        if (iit == it->second.end()) {
+          it->second.emplace(font->name(), FontSrcSense(font, std::string(files.first)));
+        }
+      } else {
+        std::map<std::string, FontSrcSense> family { {
+          font->name(),
+          FontSrcSense(font, std::string(files.first))
+        } };
+        font_families.emplace(font->family(), std::move(family));
+      }
+    }
+  }
 
-	for (auto [family, fonts] : font_families) {
-		FontSrcList font_list;
+  for (auto [family, fonts] : font_families) {
+    FontSrcList font_list;
 #ifdef HAVE_LOG
-		printf("family: %s\n", family.c_str());
+    printf("family: %s\n", family.c_str());
 #endif
-		for (auto [_name, src] : fonts) {
+    for (auto [_name, src] : fonts) {
 #ifdef HAVE_LOG
-			printf("found: %s\n", _name.c_str());
+      printf("found: %s\n", _name.c_str());
 #endif
-			font_list.push_back(std::make_unique<FontSrcSense>(src));
-		}
-		FontContext::addMainFont(family, font_list);
-	}
+      font_list.push_back(std::make_unique<FontSrcSense>(src));
+    }
+    FontContext::addMainFont(family, font_list);
+  }
 
-	font_paths_free(font_paths);
+  FontPathsFree(font_paths);
 
-	return mathfont;
+  return mathfont;
 }
 
 }

--- a/lib/otf/fontsense.cpp
+++ b/lib/otf/fontsense.cpp
@@ -65,19 +65,19 @@ font_paths_t get_font_paths() {
 		if (fs::exists(p))
 			for (const auto& entry : fs::directory_iterator(p)) {
 				fs::path path = entry.path();
-				std::string stem = path.stem();
-				std::string ext = path.extension();
+				std::string stem = path.stem().string();
+				std::string ext = path.extension().string();
 				font_paths_t::iterator it = font_paths.find(stem);
 				if (it != font_paths.end()) {
 					if (ext == ".otf" && !it->second.first)
-						it->second.first = strdup(path.c_str());
+						it->second.first = strdup(path.string().c_str());
 					if (ext == ".clm" && !it->second.second)
-						it->second.second = strdup(path.c_str());
+						it->second.second = strdup(path.string().c_str());
 
 				} else {
 					font_paths.emplace(stem, std::pair(
-						ext == ".otf" ? strdup(path.c_str()) : NULL,
-						ext == ".clm" ? strdup(path.c_str()) : NULL
+						ext == ".otf" ? strdup(path.string().c_str()) : NULL,
+						ext == ".clm" ? strdup(path.string().c_str()) : NULL
 					));
 				}
 			}

--- a/lib/otf/fontsense.cpp
+++ b/lib/otf/fontsense.cpp
@@ -1,0 +1,159 @@
+#include "fontsense.h"
+#include "unimath/uni_font.h"
+
+#include <stdlib.h>
+#include <queue>
+#include <string.h>
+#include <sstream>
+#include <filesystem>
+#include <optional>
+
+namespace fs = std::filesystem;
+
+#define FONTDIR "tinytex"
+
+namespace tinytex {
+
+font_paths_t get_font_paths() {
+	std::queue<std::string> paths;
+	// checks if TINYTEX_FONTDIR exists. If it does, it pushes it to potential paths.
+	char* devdir = getenv("TINYTEX_FONTDIR");
+	if (devdir && *devdir)
+		paths.push(std::string(devdir));
+
+	// checks if XDG_DATA_HOME exists. If it does, it pushes it to potential paths.
+	char* userdata = getenv("XDG_DATA_HOME");
+	if (userdata && *userdata)
+		paths.push(std::string(userdata) + "/" + FONTDIR);
+
+	// checks if XDG_DATA_DIRS is set. If it is, it splits XDG_DATA_DIRS at : and
+	// pushes each part of it to potential paths.
+	char* data_dirs = getenv("XDG_DATA_DIRS");
+	if (data_dirs && *data_dirs) {
+		std::stringstream data_dir_paths(data_dirs);
+		std::string data_dir_path;
+		while(getline(data_dir_paths, data_dir_path, ':'))
+			paths.push(data_dir_path + "/" + FONTDIR);
+	}
+
+#ifndef _WIN32
+	char* home = getenv("HOME");
+	if (home || *home) {
+		char* userdata_fallback;
+		asprintf(&userdata_fallback, "%s/.local/share/%s/", home, FONTDIR);
+		paths.push(std::string(userdata_fallback));
+		free(userdata_fallback);
+	}
+
+	paths.push("/usr/local/share/" FONTDIR);
+	paths.push("/usr/share/" FONTDIR);
+#endif
+
+	font_paths_t font_paths;
+
+	/*
+	 * Iterate over all found data dirs. For each dir iterate over
+	 * all files in it. For each font there should be a stem.otf and
+	 * stem.clm file available. This function checks if the filestem
+	 * is already in the font map and if it is, looks at the current
+	 * file extention and sets the current path to it it if is unset.
+	 * If the stem is not currently in the map it adds it together
+	 * with the current file as clm or otf.
+	 */
+	while (!paths.empty()) {
+		fs::path p = paths.front();
+		if (fs::exists(p))
+			for (const auto& entry : fs::directory_iterator(p)) {
+				fs::path path = entry.path();
+				std::string stem = path.stem();
+				std::string ext = path.extension();
+				font_paths_t::iterator it = font_paths.find(stem);
+				if (it != font_paths.end()) {
+					if (ext == ".otf" && !it->second.first)
+						it->second.first = strdup(path.c_str());
+					if (ext == ".clm" && !it->second.second)
+						it->second.second = strdup(path.c_str());
+
+				} else {
+					font_paths.emplace(stem, std::pair(
+						ext == ".otf" ? strdup(path.c_str()) : NULL,
+						ext == ".clm" ? strdup(path.c_str()) : NULL
+					));
+				}
+			}
+		paths.pop();
+	}
+
+	/*
+	 * Iterate over all font paths in map and remove all of them
+	 * where either the oth or clm path is NULL.
+	 */
+	for (font_paths_t::iterator it = font_paths.begin(); it != font_paths.end(); ) {
+		if (!it->second.first || !it->second.second)
+			font_paths.erase(it++);
+		else
+			it++;
+	}
+
+	return font_paths;
+}
+
+void font_paths_free(font_paths_t font_paths) {
+	for (auto [_stem, files] : font_paths) {
+		free(files.first);
+		free(files.second);
+	}
+}
+
+std::optional<const std::string> fontsense_lookup() {
+	std::optional<std::string> mathfont;
+
+	font_paths_t font_paths = get_font_paths();
+
+	font_families_t font_families;
+
+	for (const auto& [_stem, files] : font_paths) {
+		Otf* font = Otf::fromFile(files.second);
+		if (font->isMathFont()) {
+			FontContext::addMathFont(FontSrcSense(font, std::string(files.first)));
+
+			if (!mathfont)
+				mathfont = font->name();
+		}
+		else {
+			font_families_t::iterator it = font_families.find(font->family());
+			if (it != font_families.end()) {
+				auto iit = it->second.find(font->name());
+				if (iit == it->second.end()) {
+					it->second.emplace(font->name(), FontSrcSense(font, std::string(files.first)));
+				}
+			} else {
+				std::map<std::string, FontSrcSense> family { {
+					font->name(),
+					FontSrcSense(font, std::string(files.first))
+				} };
+				font_families.emplace(font->family(), std::move(family));
+			}
+		}
+	}
+
+	for (auto [family, fonts] : font_families) {
+		FontSrcList font_list;
+#ifdef HAVE_LOG
+		printf("family: %s\n", family.c_str());
+#endif
+		for (auto [_name, src] : fonts) {
+#ifdef HAVE_LOG
+			printf("found: %s\n", _name.c_str());
+#endif
+			font_list.push_back(std::make_unique<FontSrcSense>(src));
+		}
+		FontContext::addMainFont(family, font_list);
+	}
+
+	font_paths_free(font_paths);
+
+	return mathfont;
+}
+
+}

--- a/lib/otf/fontsense.cpp
+++ b/lib/otf/fontsense.cpp
@@ -14,6 +14,25 @@ namespace fs = std::filesystem;
 
 namespace tinytex {
 
+#ifdef _WIN32
+#include <windows.h>
+// Get dir of executable
+// For example, the full path is c:\x\y\z\a.exe
+// return c:\x\y\z\
+//
+std::string getDirOfExecutable() {
+  char szBuff[MAX_PATH] = {0};
+  // WIN API: GetModuleFileNameA
+  // retrieves the path of the executable file of the current process
+  // see https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea
+  GetModuleFileNameA(nullptr,szBuff, MAX_PATH);
+  std::string exePath(szBuff);
+  auto pos = exePath.find_last_of('\\');
+  // pos + 1 for adding last \ to path
+  return exePath.substr(0, pos + 1);
+}
+#endif
+
 font_paths_t GetFontPaths() {
   std::queue<std::string> paths;
   // checks if TINYTEX_FONTDIR exists. If it does, it pushes it to potential paths.
@@ -47,6 +66,9 @@ font_paths_t GetFontPaths() {
 
   paths.push("/usr/local/share/" FONTDIR);
   paths.push("/usr/share/" FONTDIR);
+#else
+  auto exeDir = getDirOfExecutable();
+  paths.push(exeDir + std::string("share/" FONTDIR));
 #endif
 
   font_paths_t font_paths;

--- a/lib/otf/fontsense.h
+++ b/lib/otf/fontsense.h
@@ -1,0 +1,19 @@
+#include <map>
+#include <optional>
+#include <string>
+
+#include "otf/otf.h"
+#include "unimath/font_src.h"
+
+namespace tinytex {
+// Map<FileStem, <OTF File, CLM File>>
+typedef std::map<std::string, std::pair<char*, char*>> font_paths_t;
+
+// Map<FontFamily, Map<Name, Fonts>>
+typedef std::map<std::string, std::map<std::string, FontSrcSense>> font_families_t;
+
+font_paths_t get_font_paths();
+void font_paths_free(font_paths_t font_paths);
+
+std::optional<const std::string> fontsense_lookup();
+}

--- a/lib/otf/fontsense.h
+++ b/lib/otf/fontsense.h
@@ -12,8 +12,8 @@ typedef std::map<std::string, std::pair<char*, char*>> font_paths_t;
 // Map<FontFamily, Map<Name, Fonts>>
 typedef std::map<std::string, std::map<std::string, FontSrcSense>> font_families_t;
 
-font_paths_t get_font_paths();
-void font_paths_free(font_paths_t font_paths);
+font_paths_t GetFontPaths();
+void FontPathsFree(font_paths_t font_paths);
 
-std::optional<const std::string> fontsense_lookup();
+std::optional<const std::string> FontsenseLookup();
 }

--- a/lib/otf/meson.build
+++ b/lib/otf/meson.build
@@ -1,5 +1,6 @@
 otf_src = [
 	'otf/clm.cpp',
+    'otf/fontsense.cpp',
 	'otf/glyph.cpp',
 	'otf/otf.cpp',
 	'otf/path.cpp'
@@ -8,6 +9,7 @@ otf_src = [
 if install_headerfiles
 	install_headers([
 		'clm.h',
+        'fontsense.h',
 		'glyph.h',
 		'math_consts.h',
 		'otf.h',

--- a/lib/otf/otf.h
+++ b/lib/otf/otf.h
@@ -46,6 +46,8 @@ public:
 /** Class to represent an otf font */
 class Otf final {
 private:
+  std::string _name;
+
   u16 _unicodeCount = 0;
   u32* _unicodes = nullptr;
   u16* _unicodeGlyphs = nullptr;
@@ -78,6 +80,9 @@ public:
 
   /** Read otf font from data */
   static Otf* fromData(size_t len, const u8* data);
+
+  /** Get the full postscript name of this font */
+  inline std::string& name() { return _name; }
 
   /** Test if this font is a math font */
   inline bool isMathFont() const { return _isMathFont; }

--- a/lib/otf/otf.h
+++ b/lib/otf/otf.h
@@ -47,6 +47,7 @@ public:
 class Otf final {
 private:
   std::string _name;
+  std::string _family;
 
   u16 _unicodeCount = 0;
   u32* _unicodes = nullptr;
@@ -81,8 +82,11 @@ public:
   /** Read otf font from data */
   static Otf* fromData(size_t len, const u8* data);
 
-  /** Get the full postscript name of this font */
+  /** Get the postscript family name of this font */
   inline std::string& name() { return _name; }
+  /** Get the full postscript name of this font */
+  inline std::string& family() { return _family; }
+
 
   /** Test if this font is a math font */
   inline bool isMathFont() const { return _isMathFont; }

--- a/lib/tinytex.cpp
+++ b/lib/tinytex.cpp
@@ -14,21 +14,27 @@ std::string TinyTeX::_defaultMathFontName;
 std::string TinyTeX::_defaultMainFontName;
 
 void TinyTeX::init(Init init) {
+  auto initialization = [&]() {
+    if (_isInited) return;
+    _isInited = true;
+    NewCommandMacro::_init_();
+  };
+
   const FontSrc** mathFontSrc = std::get_if<const FontSrc*>(&init);
-  if (mathFontSrc) {
+  if (mathFontSrc != nullptr) {
     FontContext::addMathFont(**mathFontSrc);
     _defaultMathFontName = (*mathFontSrc)->name;
-    goto initialization;
+    return initialization();
   }
 
   {
-  auto mathfont = fontsense_lookup();
+  auto mathfont = FontsenseLookup();
   {
   const std::string* mathFontName= std::get_if<const std::string>(&init);
-  if (mathFontName) {
+  if (mathFontName != nullptr) {
     _defaultMathFontName = *mathFontName;
-	FontContext().selectMathFont(_defaultMathFontName);
-    goto initialization;
+    FontContext().selectMathFont(_defaultMathFontName);
+    return initialization();
   }
   }
 
@@ -38,9 +44,7 @@ void TinyTeX::init(Init init) {
     throw ex_invalid_param("no math font found by fontsense");
   }
 
-  initialization:if (_isInited) return;
-  _isInited = true;
-  NewCommandMacro::_init_();
+  return initialization();
 }
 
 bool TinyTeX::isInited() {

--- a/lib/tinytex.cpp
+++ b/lib/tinytex.cpp
@@ -27,6 +27,7 @@ void TinyTeX::init(Init init) {
   const std::string* mathFontName= std::get_if<const std::string>(&init);
   if (mathFontName) {
     _defaultMathFontName = *mathFontName;
+	FontContext().selectMathFont(_defaultMathFontName);
     goto initialization;
   }
   }
@@ -34,7 +35,7 @@ void TinyTeX::init(Init init) {
   if (mathfont)
     _defaultMathFontName = mathfont.value();
   else
-    throw ex_invalid_state("no math font found by fontsense");
+    throw ex_invalid_param("no math font found by fontsense");
   }
 
   initialization:if (_isInited) return;

--- a/lib/tinytex.h
+++ b/lib/tinytex.h
@@ -2,12 +2,16 @@
 #define TINYTEX_TINYTEX_H
 
 #include <string>
+#include <variant>
 
 #include "unimath/font_src.h"
 #include "config.h"
 #include "render.h"
 
 namespace tinytex {
+
+struct TINYTEX_EXPORT InitFontSenseAuto { };
+typedef std::variant<const FontSrc*, const std::string, InitFontSenseAuto> Init;
 
 class TINYTEX_EXPORT TinyTeX {
 private:
@@ -26,7 +30,7 @@ public:
    *
    * @param mathFontSrc the font source to load math font
    */
-  static void init(const FontSrc& mathFontSrc);
+  static void init(Init init);
 
   /** Check if context is initialized */
   static bool isInited();

--- a/lib/unimath/font_src.cpp
+++ b/lib/unimath/font_src.cpp
@@ -23,3 +23,11 @@ FontSrcData::FontSrcData(std::string name, size_t len, const u8* data, std::stri
 sptr<Otf> FontSrcData::loadOtf() const {
   return sptr<Otf>(Otf::fromData(len, data));
 }
+
+FontSrcSense::FontSrcSense(Otf* clm_file, std::string font_file)
+	: FontSrc(clm_file->name(), std::move(font_file)),
+	  clm_file(clm_file) {}
+
+sptr<Otf> FontSrcSense::loadOtf() const {
+	return sptr<Otf>(clm_file);
+}

--- a/lib/unimath/font_src.h
+++ b/lib/unimath/font_src.h
@@ -58,6 +58,15 @@ public:
   sptr<Otf> loadOtf() const override;
 };
 
+class FontSrcSense : public FontSrc {
+public:
+	Otf* clm_file;
+
+	FontSrcSense(Otf* clm_file, std::string font_file);
+
+	sptr<Otf> loadOtf() const override;
+};
+
 using FontSrcList = std::vector<std::unique_ptr<FontSrc>>;
 
 }

--- a/platform/wasm/capi.cpp
+++ b/platform/wasm/capi.cpp
@@ -16,7 +16,7 @@ void TINYTEX_WASM_API tinytex_init(
   const unsigned char* data
 ) {
   FontSrcData src{name, len, data};
-  TinyTeX::init(src);
+  TinyTeX::init(&src);
 }
 
 void TINYTEX_WASM_API tinytex_release() {

--- a/prebuilt/otf2clm.py
+++ b/prebuilt/otf2clm.py
@@ -631,6 +631,7 @@ def parse_otf(file_path, have_glyph_path, output_file_path):
         for l in liga_info:
             ligas.append(l)
 
+    name = font.fullname
     em = font.em
     xheight = font.xHeight
     ascent = font.ascent
@@ -644,6 +645,7 @@ def parse_otf(file_path, have_glyph_path, output_file_path):
         f.write(struct.pack('!H', 2))
         # minor version, if support glyph path
         f.write(struct.pack('B', 2 if have_glyph_path else 1))
+        f.write(struct.pack(str(len(name)+1) + 's', bytes(name, 'utf-8')))
         f.write(struct.pack('?', is_math_font))
         f.write(struct.pack('!H', em))
         f.write(struct.pack('!H', int(xheight)))

--- a/prebuilt/otf2clm.py
+++ b/prebuilt/otf2clm.py
@@ -642,8 +642,8 @@ def parse_otf(file_path, have_glyph_path, output_file_path):
         f.write(struct.pack('c', bytes('c', 'ascii')))
         f.write(struct.pack('c', bytes('l', 'ascii')))
         f.write(struct.pack('c', bytes('m', 'ascii')))
-        # current major version 2
-        f.write(struct.pack('!H', 2))
+        # current major version 3
+        f.write(struct.pack('!H', 3))
         # minor version, if support glyph path
         f.write(struct.pack('B', 2 if have_glyph_path else 1))
         f.write(struct.pack(str(len(name)+1) + 's', bytes(name, 'utf-8')))

--- a/prebuilt/otf2clm.py
+++ b/prebuilt/otf2clm.py
@@ -632,6 +632,7 @@ def parse_otf(file_path, have_glyph_path, output_file_path):
             ligas.append(l)
 
     name = font.fullname
+    family = font.familyname
     em = font.em
     xheight = font.xHeight
     ascent = font.ascent
@@ -646,6 +647,7 @@ def parse_otf(file_path, have_glyph_path, output_file_path):
         # minor version, if support glyph path
         f.write(struct.pack('B', 2 if have_glyph_path else 1))
         f.write(struct.pack(str(len(name)+1) + 's', bytes(name, 'utf-8')))
+        f.write(struct.pack(str(len(family)+1) + 's', bytes(family, 'utf-8')))
         f.write(struct.pack('?', is_math_font))
         f.write(struct.pack('!H', em))
         f.write(struct.pack('!H', int(xheight)))


### PR DESCRIPTION
In #87 you've said that
>> fallback fonts
>
> Probably no. In my submission, it is the user's responsibility to provide the font with the clm data file, but it needs to be discussed.

But for [NoteKit](https://github.com/blackhole89/notekit), we'd prefer if font handling will be done by clatexmath, rather than notekit. This PR is basically implementing a way of doing this:

It first looks at all potential tinytex data dirs (`$TINYTEX_FONTDIR`, `$XDG_DATA_HOME/tinytex`, `$XDG_DATA_DIRS[@]/tinytex`, `/usr/local/share/tinytex` and `/usr/share/tinytex`) and in for there to be a valid font there needs to be a `FontName.otf` and a `FontName.clm` file in these directories. 

The clm file spec has been changed to include postscript full name and postscript family name after the `has_glyph_path` byte (see the BinaryReader::read_string and lookfwd method), so that the found clm files can be parsed and included in the FontContext as their name.

To accommodate for this, the `LaTeX::init` method had to be changed. Instead of a `const FontSrc&` it now takes a `std::variant<const FontSrc*, const std::string*, {}>`, to either: init clm with a fontspec, like it worked before (alsotho variants can't seem to contain references, so one now needs to borrow the fontspec when initializing), init clm with a specific mathfont that the progrom will expect to be found or with nothing (`InitFontSenseAuto`), then first mathfont that is encountered will also become the default math font.

Currently I'll label this PR as a WIP, because there are still a few bugs to fix and it can surely be still improved.


I also found a bug (I think), in the way non math font families are handled. I've tried to put NoteKit's fontfamily "Charter" (https://github.com/blackhole89/notekit/tree/master/data/fonts) into the search dir, and the font senser also found all of them and added all of them with a single `LaTeX::addMainFont` invocation as "Charter" family. However, after calling `LaTeX::setDefaultMainFont("Charter")` instead of picking the correct style for `\text{}` it instead used the one that was in the last position of the FontSrcList, which happened to be "Charter Italic".

---

## TODO:
- [ ] fix the bug described above
- [x] windows compatibly. I'm unable to test against any Windows OS, so I don't know if it works there as the windows CI seems currently broken. Additionally, I'd like to extend the font senser for windows to look for $DIR_OF_EXECUTABLE/share/tinytex, so our notekit windows build will continue to work. I imagine this similar to glib's [g_win32_get_system_data_dirs_for_module](https://gitlab.gnome.org/GNOME/glib/-/blob/main/glib/gutils.c#L2527) which is used in [g_get_system_data_dirs](https://docs.gtk.org/glib/func.get_system_data_dirs.html) on windows. maybe @PikachuHy could help here.